### PR TITLE
Adds info on Bayer to board, placeholder for the rest

### DIFF
--- a/docs/consortium/index.html
+++ b/docs/consortium/index.html
@@ -127,6 +127,27 @@
 
 <p>Consortium members <em>partner</em> to advance force fields. Thus, the Consortium is a true collaboration, not just a funding initiative. Industry partners often have tremendous expertise in the strengths and weaknesses of force fields and the Initiative can greatly benefit from their expertise. Thus, our seven-member Governing Board includes elected representatives from supporting Partners who help plan our science. Additionally, we have an extensive Advisory Board including members from all Partners that contribute above a threshold level of support. This board provides input on scientific directions and project plans, and elects industry representatives to the Governing Board. Both boards are involved in regular calls and meetings with the Principal Investigators as part of the Initiative.</p>
 
+<h2 id="consortium-governance-and-leadership">Consortium governance and leadership</h2>
+
+<h3 id="governing-board">Governing Board</h3>
+
+<ul>
+<li>John D. Chodera (MSKCC)</li>
+<li>Michael K. Gilson (UCSD)</li>
+<li>Katharina Meier (Bayer)</li>
+<li>David L. Mobley (UCI)</li>
+<li>Michael R. Shirts (CU Boulder)</li>
+<li>Lee-Ping Wang (UC Davis)</li>
+<li>Additional industry member to be disclosed following legal approval</li>
+</ul>
+
+<h3 id="advisory-board">Advisory Board</h3>
+
+<ul>
+<li>Katharina Meier (Bayer)</li>
+<li>Seven additional members to be disclosed following legal approval</li>
+</ul>
+
 </div>
 </main>
   <footer>

--- a/openforcefield/content/consortium/_index.md
+++ b/openforcefield/content/consortium/_index.md
@@ -16,3 +16,19 @@ The **Open Force Field Consortium** is composed of academic investigators from t
 ## The Consortium uses a collaborative, shared-governance model
 
 Consortium members *partner* to advance force fields. Thus, the Consortium is a true collaboration, not just a funding initiative. Industry partners often have tremendous expertise in the strengths and weaknesses of force fields and the Initiative can greatly benefit from their expertise. Thus, our seven-member Governing Board includes elected representatives from supporting Partners who help plan our science. Additionally, we have an extensive Advisory Board including members from all Partners that contribute above a threshold level of support. This board provides input on scientific directions and project plans, and elects industry representatives to the Governing Board. Both boards are involved in regular calls and meetings with the Principal Investigators as part of the Initiative.
+
+## Consortium governance and leadership
+
+### Governing Board
+- John D. Chodera (MSKCC)
+- Michael K. Gilson (UCSD)
+- Katharina Meier (Bayer)
+- David L. Mobley (UCI)
+- Michael R. Shirts (CU Boulder)
+- Lee-Ping Wang (UC Davis)
+- Additional industry member to be disclosed following legal approval
+
+
+### Advisory Board
+- Katharina Meier (Bayer)
+- Seven additional members to be disclosed following legal approval


### PR DESCRIPTION
We're waiting for legal approval to list most of the board members on the website. However, Katharina Meier (Bayer) is OK to be listed (as long as we don't use their logo).

This adds Meier, as well as placeholders for the other advisory board members (and governing board member) to be added once approval is in place.