### PR TITLE
Add Ian Craig (BASF)

### DIFF
--- a/docs/consortium/index.html
+++ b/docs/consortium/index.html
@@ -133,20 +133,21 @@
 
 <ul>
 <li>John D. Chodera (MSKCC)</li>
+<li>Thomas Fox (Boehringer-Ingelheim)</li>
 <li>Michael K. Gilson (UCSD)</li>
 <li>Katharina Meier (Bayer)</li>
 <li>David L. Mobley (UCI)</li>
 <li>Michael R. Shirts (CU Boulder)</li>
 <li>Lee-Ping Wang (UC Davis)</li>
-<li>Additional industry member to be disclosed following legal approval</li>
 </ul>
 
 <h3 id="advisory-board">Advisory Board</h3>
 
 <ul>
 <li>Ian Craig (BASF)</li>
+<li>Thomas Fox (Boehringer-Ingelheim)</li>
 <li>Katharina Meier (Bayer)</li>
-<li>Six additional members to be disclosed following legal approval</li>
+<li>Five additional members to be disclosed following legal approval</li>
 </ul>
 
 </div>

--- a/docs/consortium/index.html
+++ b/docs/consortium/index.html
@@ -144,8 +144,9 @@
 <h3 id="advisory-board">Advisory Board</h3>
 
 <ul>
+<li>Ian Craig (BASF)</li>
 <li>Katharina Meier (Bayer)</li>
-<li>Seven additional members to be disclosed following legal approval</li>
+<li>Six additional members to be disclosed following legal approval</li>
 </ul>
 
 </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -57,13 +57,13 @@
   </url>
   
   <url>
-    <loc>//openforcefield.org/tags/news/</loc>
+    <loc>//openforcefield.org/categories/news/</loc>
     <lastmod>2018-10-06T00:00:00+00:00</lastmod>
     <priority>0</priority>
   </url>
   
   <url>
-    <loc>//openforcefield.org/categories/news/</loc>
+    <loc>//openforcefield.org/tags/news/</loc>
     <lastmod>2018-10-06T00:00:00+00:00</lastmod>
     <priority>0</priority>
   </url>

--- a/openforcefield/content/consortium/_index.md
+++ b/openforcefield/content/consortium/_index.md
@@ -21,15 +21,16 @@ Consortium members *partner* to advance force fields. Thus, the Consortium is a 
 
 ### Governing Board
 - John D. Chodera (MSKCC)
+- Thomas Fox (Boehringer-Ingelheim)
 - Michael K. Gilson (UCSD)
 - Katharina Meier (Bayer)
 - David L. Mobley (UCI)
 - Michael R. Shirts (CU Boulder)
 - Lee-Ping Wang (UC Davis)
-- Additional industry member to be disclosed following legal approval
 
 
 ### Advisory Board
 - Ian Craig (BASF)
+- Thomas Fox (Boehringer-Ingelheim)
 - Katharina Meier (Bayer)
-- Six additional members to be disclosed following legal approval
+- Five additional members to be disclosed following legal approval

--- a/openforcefield/content/consortium/_index.md
+++ b/openforcefield/content/consortium/_index.md
@@ -30,5 +30,6 @@ Consortium members *partner* to advance force fields. Thus, the Consortium is a 
 
 
 ### Advisory Board
+- Ian Craig (BASF)
 - Katharina Meier (Bayer)
-- Seven additional members to be disclosed following legal approval
+- Six additional members to be disclosed following legal approval


### PR DESCRIPTION
BASF legal review passed so Ian Craig is OK to go up on website now.