### PR TITLE
Update description for the learned chemical perception paper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# OS X extra files
+*.DS_Store
+

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -116,14 +116,14 @@
 
   <li itemscope itemtype="http://schema.org/CreativeWork">
     <h2 class="title">
-        <a href="//openforcefield.org/categories/minutes/" itemprop="headline">Minutes</a>
+        <a href="//openforcefield.org/categories/science/" itemprop="headline">Science</a>
     </h2>
     <hr>
     
 </li>
   <li itemscope itemtype="http://schema.org/CreativeWork">
     <h2 class="title">
-        <a href="//openforcefield.org/categories/science/" itemprop="headline">Science</a>
+        <a href="//openforcefield.org/categories/minutes/" itemprop="headline">Minutes</a>
     </h2>
     <hr>
     

--- a/docs/consortium/index.html
+++ b/docs/consortium/index.html
@@ -152,7 +152,7 @@
 <li>Daniel Kuhn (Merck KGaA), Vice Chair</li>
 <li>Katharina Meier (Bayer)</li>
 <li>Arjun Narayanan (Vertex), Secretary</li>
-<li>Several additional members to be disclosed following legal approval</li>
+<li>Five additional members to be disclosed following legal approval</li>
 </ul>
 
 <h3 id="meeting-minutes">Meeting Minutes</h3>

--- a/docs/consortium/minutes/2018-10-11-minutes/index.html
+++ b/docs/consortium/minutes/2018-10-11-minutes/index.html
@@ -130,7 +130,7 @@
 
 <p>Attending: All PIs except Shirts, and both industry members, Thomas Fox and Katharina Meier</p>
 
-<p>Shared our detailed budget outline went over the proposed initial personnel. Approved were:</p>
+<p>Shared the detailed budget outline Google Doc and went over the personnel who would be involved and their distribution across different locations, $ amounts, etc. Approved were:</p>
 
 <ul>
 <li>Jeff Wagner, software scientist/postdoc at UCI, who already started but initiative funds will begin ASAP.</li>

--- a/docs/publications/index.html
+++ b/docs/publications/index.html
@@ -187,7 +187,7 @@
               <br>
           
 
-          <i>This paper introduces the SMIRNOFF format in the context of traditional force fields, explains the development and validation of our new small molecule force field smirnoff99Frosst, and highlights some directions the initiative is headed.</i><br>
+          <i>Here, we introduce a proof of principle for automatically sampling chemical perception compared to traditional atom typed force fields and our SMIRNOFF format.</i><br>
         </p>
       </div>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -73,7 +73,7 @@
   </url>
   
   <url>
-    <loc>//openforcefield.org/categories/news/</loc>
+    <loc>//openforcefield.org/tags/news/</loc>
     <lastmod>2018-10-06T00:00:00+00:00</lastmod>
     <priority>0</priority>
   </url>

--- a/openforcefield/data/publications/publications.yaml
+++ b/openforcefield/data/publications/publications.yaml
@@ -9,7 +9,7 @@
     date: 2018-07-13
 - title: "Toward learned chemical perception of force field typing rules"
   authors: "Camila Zanette, Caitlin C. Bannan, Christopher I. Bayly, Josh Fass, Michael K. Gilson, Michael R. Shirts, John Chodera, and David L. Mobley"
-  summary: This paper introduces the SMIRNOFF format in the context of traditional force fields, explains the development and validation of our new small molecule force field smirnoff99Frosst, and highlights some directions the initiative is headed.
+  summary: Here, we introduce a proof of principle for automatically sampling chemical perception compared to traditional atom typed force fields and our SMIRNOFF format. 
   img: smarty.jpg
   preprint:
     server: chemRxiv


### PR DESCRIPTION
On Monday we realized the learned chemical perception paper had the same description as the SMIRNOFF paper. I've added a new description for the learned chemical perception paper. 