### PR TITLE
Add Janssen postdoc ad

### DIFF
--- a/docs/jobs/index.html
+++ b/docs/jobs/index.html
@@ -116,6 +116,10 @@
 <div id="kube-faq">
 
 
+<p><a id="initiative-postdoc"/></p>
+
+<h2 id="open-force-field-initiative-postdoc">Open Force Field Initiative Postdoc</h2>
+
 <p>The <strong>Open Force Field Initiative</strong> is seeking talented postdoctoral fellows to work on the development of modern toolkits and new methods for building next-generation molecular mechanics force fields.
 These positions are supported by the <a href="https://openforcefield.org/consortium/">Open Force Field Consortium</a>, which is administered by the <a href="http://molssi.org">Molecular Sciences Software Institute (MolSSI)</a> and funded by an <a href="https://openforcefield.org/news/introducing-the-consortium/">alliance of pharmaceutical and biotech companies</a> aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort.
 Postdocs will work closely with other researchers in the Initiative, multiple academic Initiative PIs, industry Partner scientific collaborators, and software scientists in the at <a href="http://molssi.org">MolSSI</a> to develop and apply new algorithms and modern open source software infrastructure for building high quality biomolecular force fields.
@@ -169,6 +173,59 @@ We aim to publish frequently and openly&mdash;a sample of existing publications 
 <li>a detailed Curriculum Vitae (including a list of publications)</li>
 <li>contact information of two references</li>
 </ul>
+
+<hr />
+
+<p><a id="janssen-postdoc"/></p>
+
+<h2 id="janssen-distinguished-open-force-field-consortium-postdoc">Janssen Distinguished Open Force Field Consortium Postdoc</h2>
+
+<p><a href="https://openforcefield.org/consortium/">Open Force Field Consortium</a> Partner <a href="https://www.jnj.com/">Janssen Research &amp; Development</a> is hiring a postdoc to work on open source, open science <a href="https://openforcefield.org/consortium/">Open Force Field Consortium</a> projects!
+The position will be supervised by <a href="https://openforcefield.org/members/">Open Force Field Investigators</a> and co-mentored by talented J&amp;J computational chemists, including <a href="https://scholar.google.es/citations?user=uMYJoIkAAAAJ&amp;hl=en">Gary Tresadern</a>.
+The position is located at the <a href="https://www.janssen.com/sites/www_janssen_com_belgium/files/pdf/150310%20JanssenBelgiumBrochure_ENGLISH_DUTCH_FRENC.pdf">J&amp;J Beerse site in Belgium</a>.</p>
+
+<p>Apply via the J&amp;J site here: <a href="https://jobs.jnj.com/jobs/1905719143W?lang=en-us">https://jobs.jnj.com/jobs/1905719143W?lang=en-us</a></p>
+
+<p>(Text of ad reprinted below)</p>
+
+<p>Requisition ID: <a href="https://jobs.jnj.com/jobs/1905719143W?lang=en-us">1905719143W</a></p>
+
+<p>Janssen Research &amp; Development seeks to drive innovation and deliver transformational medicines for the treatment of diseases in six therapeutic areas: neuroscience, cardiovascular diseases and metabolism, infectious diseases, immunology, oncology and pulmonary hypertension. In these areas, Janssen aims to address and solve unmet medical needs through the development of small and large molecules, as well as vaccines. The Janssen campus in Beerse (Belgium) has a unique ecosystem covering the complete drug development life cycle, with all capabilities from basic science to market access on one campus. The integrated environment of our campus gives our people the chance to experience many different aspects of drug development throughout their career. It has a successful track record of over sixty years of drug discovery and development and is one of the most important innovation engines of the Janssen group worldwide.</p>
+
+<p>Developing innovative therapeutics to treat diseases like Alzheimer’s disease, various types of cancers and infectious diseases like Hepatitis B, influenza is our passion. In this endeavor, we are seeking to recruit new talent for the comprehensive analyses of high-dimensional datasets using state-of-the-art data science methods applied to drug discovery programs. The position will be opened on the Beerse campus, which is the flagship R&amp;D center for small molecules within Janssen, investing over 1 billion euros each year in R&amp;D.</p>
+
+<p>We are looking for a highly skilled and motivated <strong>computational chemist</strong> for the position of <strong>PostDoc – Open Force Field, Computational Chemistry</strong>, at our Beerse, Belgium site. The position is part of the Open Force Field Consortium, funded by an alliance of pharmaceutical and biotech companies aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort. The Open Force Field Initiative is a multi-investigator collaboration that aims to build new, quantitatively accurate molecular mechanics force fields supported by a modern software infrastructure, built on principles of open source, open data, and open science. Collaborating academic laboratories include: Michael K. Gilson (UCSD, La Jolla, CA), John D. Chodera (MSKCC, New York City, NY), Lee-Ping Wang (UCD, Davis, CA), David L. Mobley (UCI, Irvine, CA), or Michael R. Shirts (University of Colorado, Boulder, CO). Janssen is part of this consortium and we seek a skilled PostDoc to contribute to this exciting collaborative project.</p>
+
+<h3 id="responsibilities-of-the-postdoc-scientist-will-include">Responsibilities of the PostDoc Scientist will include:</h3>
+
+<ul>
+<li>Develop and execute clear computational programming strategies contributing to the collaboration.</li>
+<li>Work In close collaboration with the external collaborating groups to develop the force field via its different working groups</li>
+<li>Test developments of the force field on data originating from Janssen or the public domain</li>
+</ul>
+
+<h3 id="qualifications">Qualifications</h3>
+
+<ul>
+<li>Experience with the theory and practice of atomistic biomolecular simulation using molecular mechanics force fields</li>
+<li>Comfortable with the Python programming language</li>
+<li>Exposure to modern open source software development practices (GitHub, unit tests, continuous integration)</li>
+<li>Good multidisciplinary teamwork and communication skills</li>
+<li>Bonus qualifications (nice to have, but not required!):</li>
+<li>Experience with force field parameter fitting for small organic molecules</li>
+<li>Experience with quantum chemical calculations in general, and psi4 in particular</li>
+<li>Experience with high-performance computing clusters and/or cloud computing</li>
+<li>Knowledge of organic chemistry</li>
+<li>Experience with the open-source GPU-accelerated molecular simulation Python library OpenMM</li>
+<li>Experience with probabilistic programming languages (e.g. PyMC, tensorflow.Probability, Pyro) and/or machine learning frameworks like TensorFlow</li>
+<li>Experience with cheminformatics or computer-aided drug discovery</li>
+</ul>
+
+<p><strong>Appointment:</strong> The position will be for two years.</p>
+
+<p><strong>Open Force Field Initiative:</strong> To find out more about the Open Force Field Initiative, visit <a href="http://openforcefield.org">http://openforcefield.org</a>.</p>
+
+<p>Up to 10% travel may be required</p>
 
 </div>
 </main>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -153,13 +153,13 @@
   </url>
   
   <url>
-    <loc>//openforcefield.org/categories/news/</loc>
+    <loc>//openforcefield.org/tags/news/</loc>
     <lastmod>2018-10-06T00:00:00+00:00</lastmod>
     <priority>0</priority>
   </url>
   
   <url>
-    <loc>//openforcefield.org/tags/news/</loc>
+    <loc>//openforcefield.org/categories/news/</loc>
     <lastmod>2018-10-06T00:00:00+00:00</lastmod>
     <priority>0</priority>
   </url>

--- a/openforcefield/content/jobs/_index.md
+++ b/openforcefield/content/jobs/_index.md
@@ -5,6 +5,10 @@ draft: false
 layout: faq
 ---
 
+<a id="initiative-postdoc"/>
+
+## Open Force Field Initiative Postdoc
+
 The **Open Force Field Initiative** is seeking talented postdoctoral fellows to work on the development of modern toolkits and new methods for building next-generation molecular mechanics force fields.
 These positions are supported by the [Open Force Field Consortium](https://openforcefield.org/consortium/), which is administered by the [Molecular Sciences Software Institute (MolSSI)](http://molssi.org) and funded by an [alliance of pharmaceutical and biotech companies](https://openforcefield.org/news/introducing-the-consortium/) aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort.
 Postdocs will work closely with other researchers in the Initiative, multiple academic Initiative PIs, industry Partner scientific collaborators, and software scientists in the at [MolSSI](http://molssi.org) to develop and apply new algorithms and modern open source software infrastructure for building high quality biomolecular force fields.
@@ -50,3 +54,52 @@ Interested candidates should email an application to `openforcefield@choderalab.
 * a cover letter explaining your motivation, background, and qualifications for the position
 * a detailed Curriculum Vitae (including a list of publications)
 * contact information of two references
+
+---
+
+<a id="janssen-postdoc"/>
+
+## Janssen Distinguished Open Force Field Consortium Postdoc
+
+[Open Force Field Consortium](https://openforcefield.org/consortium/) Partner [Janssen Research & Development](https://www.jnj.com/) is hiring a postdoc to work on open source, open science [Open Force Field Consortium](https://openforcefield.org/consortium/) projects!
+The position will be supervised by [Open Force Field Investigators](https://openforcefield.org/members/) and co-mentored by talented J&J computational chemists, including [Gary Tresadern](https://scholar.google.es/citations?user=uMYJoIkAAAAJ&hl=en).
+The position is located at the [J&J Beerse site in Belgium](https://www.janssen.com/sites/www_janssen_com_belgium/files/pdf/150310%20JanssenBelgiumBrochure_ENGLISH_DUTCH_FRENC.pdf).
+
+Apply via the J&J site here: https://jobs.jnj.com/jobs/1905719143W?lang=en-us
+
+(Text of ad reprinted below)
+
+Requisition ID: [1905719143W](https://jobs.jnj.com/jobs/1905719143W?lang=en-us)
+
+Janssen Research & Development seeks to drive innovation and deliver transformational medicines for the treatment of diseases in six therapeutic areas: neuroscience, cardiovascular diseases and metabolism, infectious diseases, immunology, oncology and pulmonary hypertension. In these areas, Janssen aims to address and solve unmet medical needs through the development of small and large molecules, as well as vaccines. The Janssen campus in Beerse (Belgium) has a unique ecosystem covering the complete drug development life cycle, with all capabilities from basic science to market access on one campus. The integrated environment of our campus gives our people the chance to experience many different aspects of drug development throughout their career. It has a successful track record of over sixty years of drug discovery and development and is one of the most important innovation engines of the Janssen group worldwide.
+
+Developing innovative therapeutics to treat diseases like Alzheimer’s disease, various types of cancers and infectious diseases like Hepatitis B, influenza is our passion. In this endeavor, we are seeking to recruit new talent for the comprehensive analyses of high-dimensional datasets using state-of-the-art data science methods applied to drug discovery programs. The position will be opened on the Beerse campus, which is the flagship R&D center for small molecules within Janssen, investing over 1 billion euros each year in R&D.
+
+We are looking for a highly skilled and motivated **computational chemist** for the position of **PostDoc – Open Force Field, Computational Chemistry**, at our Beerse, Belgium site. The position is part of the Open Force Field Consortium, funded by an alliance of pharmaceutical and biotech companies aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort. The Open Force Field Initiative is a multi-investigator collaboration that aims to build new, quantitatively accurate molecular mechanics force fields supported by a modern software infrastructure, built on principles of open source, open data, and open science. Collaborating academic laboratories include: Michael K. Gilson (UCSD, La Jolla, CA), John D. Chodera (MSKCC, New York City, NY), Lee-Ping Wang (UCD, Davis, CA), David L. Mobley (UCI, Irvine, CA), or Michael R. Shirts (University of Colorado, Boulder, CO). Janssen is part of this consortium and we seek a skilled PostDoc to contribute to this exciting collaborative project.
+
+### Responsibilities of the PostDoc Scientist will include:
+
+* Develop and execute clear computational programming strategies contributing to the collaboration.
+* Work In close collaboration with the external collaborating groups to develop the force field via its different working groups
+* Test developments of the force field on data originating from Janssen or the public domain
+
+### Qualifications
+
+* Experience with the theory and practice of atomistic biomolecular simulation using molecular mechanics force fields
+* Comfortable with the Python programming language
+* Exposure to modern open source software development practices (GitHub, unit tests, continuous integration)
+* Good multidisciplinary teamwork and communication skills
+* Bonus qualifications (nice to have, but not required!):
+* Experience with force field parameter fitting for small organic molecules
+* Experience with quantum chemical calculations in general, and psi4 in particular
+* Experience with high-performance computing clusters and/or cloud computing
+* Knowledge of organic chemistry
+* Experience with the open-source GPU-accelerated molecular simulation Python library OpenMM
+* Experience with probabilistic programming languages (e.g. PyMC, tensorflow.Probability, Pyro) and/or machine learning frameworks like TensorFlow
+* Experience with cheminformatics or computer-aided drug discovery
+
+**Appointment:** The position will be for two years.
+
+**Open Force Field Initiative:** To find out more about the Open Force Field Initiative, visit http://openforcefield.org.
+
+Up to 10% travel may be required


### PR DESCRIPTION
We can link directly to this with http://openforcefield.org/jobs/#janssen-postdoc