### PR TITLE
Try to fix go errors by retrieving latest release of hugo instead of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 
 install:
     #- go get github.com/gohugoio/hugo@v0.54.0
-    - go get gopkg.in/gohugoio/hugo.v0.54.0
+    - go get gopkg.in/gohugoio/hugo.v0
 
 before_script:
     - rm -rf public 2> /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ go:
 
 
 install:
-    - go get github.com/gohugoio/hugo@v0.54.0
+    #- go get github.com/gohugoio/hugo@v0.54.0
+    - go get gopkg.in/gohugoio/hugo.v0.54.0
 
 before_script:
     - rm -rf public 2> /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 
 
 install:
-    - go get github.com/gohugoio/hugo
+    - go get github.com/gohugoio/hugo@v0.54.0
 
 before_script:
     - rm -rf public 2> /dev/null


### PR DESCRIPTION
Travis build/deployment is failing with
```
$ go get github.com/gohugoio/hugo
package github.com/tdewolff/minify/v2: code in directory /home/travis/gopath/src/github.com/tdewolff/minify expects import "github.com/tdewolff/minify"
package github.com/tdewolff/parse/v2: code in directory /home/travis/gopath/src/github.com/tdewolff/parse expects import "github.com/tdewolff/parse"
```
My suspicion is that this is because we actually want to be installing the latest release (`v0.54.0`) of hugo instead of `master`.