### PR TITLE
Data subpage update to include torsion dataset

### DIFF
--- a/content/datasets/_index.md
+++ b/content/datasets/_index.md
@@ -9,9 +9,8 @@ The Open Force Field Initiative makes a number of resources available to the com
 
 ---
 
-- [open-forcefield-data](https://github.com/openforcefield/open-forcefield-data): 
-  * Curated datasets from the NIST ThermoML database to be used for force field parameterization:
-    + 
+- [open-forcefield-data](https://github.com/openforcefield/open-forcefield-data): Curated datasets from the NIST ThermoML database to be used for force field parameterization.
+    
 - [MiniDrugBank](https://github.com/openforcefield/MiniDrugBank): A repository to track the creation and evolution of the MiniDrugBank Molecule set, filtered from [DrugBank Release Version 5.0.1](https://www.drugbank.ca/releases/5-0-1).
 - [Initial torsion dataset](https://github.com/openforcefield/open-forcefield-data/tree/master/Torsion-Drives/Roche-Reference-Compounds): A set of 486 small and chemically diverse molecules selected and provided by Roche used for initial torsion scanning and parameterization (see [here](https://openforcefield.org/science/updates/2019-05-16-condicj/) for more information). This dataset contains: 
   * [2D representations of molecules (PDF)]( https://github.com/openforcefield/open-forcefield-data/blob/master/Torsion-Drives/Roche-Reference-Compounds/OpenFF_references.pdf) in Roche set;

--- a/content/datasets/_index.md
+++ b/content/datasets/_index.md
@@ -9,5 +9,11 @@ The Open Force Field Initiative makes a number of resources available to the com
 
 ---
 
-- [open-forcefield-data](https://github.com/openforcefield/open-forcefield-data): Curated datasets from the NIST ThermoML database to be used for force field parameterization.
+- [open-forcefield-data](https://github.com/openforcefield/open-forcefield-data): 
+  * Curated datasets from the NIST ThermoML database to be used for force field parameterization:
+    + 
 - [MiniDrugBank](https://github.com/openforcefield/MiniDrugBank): A repository to track the creation and evolution of the MiniDrugBank Molecule set, filtered from [DrugBank Release Version 5.0.1](https://www.drugbank.ca/releases/5-0-1).
+- [Initial torsion dataset](https://github.com/openforcefield/open-forcefield-data/tree/master/Torsion-Drives/Roche-Reference-Compounds): A set of 486 small and chemically diverse molecules selected and provided by Roche used for initial torsion scanning and parameterization (see [here](https://openforcefield.org/science/updates/2019-05-16-condicj/) for more information). This dataset contains: 
+  * [2D representations of molecules (PDF)]( https://github.com/openforcefield/open-forcefield-data/blob/master/Torsion-Drives/Roche-Reference-Compounds/OpenFF_references.pdf) in Roche set;
+  * [SDF files](https://github.com/openforcefield/open-forcefield-data/blob/master/Torsion-Drives/Roche-Reference-Compounds/OpenFF_references.sdf);
+  * [Computed torsion profiles](https://github.com/openforcefield/open-forcefield-data/tree/master/Torsion-Drives/Roche-Reference-Compounds/Group1-820/b3lyp_631gs_local_ucd) for a selected subset of 820 torsions. 


### PR DESCRIPTION
Including links to torsion dataset in open-forcefield-data. I will update this page in a more systematic way later.

![image](https://user-images.githubusercontent.com/32760282/58124601-a606dd00-7bdc-11e9-8fe5-866e4fff9acb.png)
