### PR TITLE
Fixing DOI for OFFCW Jan 20 2019 roadmap presentation

### DIFF
--- a/content/science/_index.md
+++ b/content/science/_index.md
@@ -13,7 +13,7 @@ Read about where we're headed.
 
 [May 2019 Roadmap Update](downloads/roadmap/roadmap-graphic-may-2019-update.pdf)
 
-Roadmap Presentation at January 2019 Consortium Workshop [[DOI]](http://10.13140/RG.2.2.27587.86562)
+Roadmap Presentation at January 2019 Consortium Workshop [[DOI]](http://doi.org/10.5281/zenodo.3228414)
 
 # Presentations
 


### PR DESCRIPTION
The link now takes visitors to Zenodo and the presentation has a different DOI. The RG DOI is linked too in the metadata, as is the accompanying YouTube video. Fixed #102 

![image](https://user-images.githubusercontent.com/32760282/58352408-71439180-7e39-11e9-949f-863deafd1d89.png)
