### PR TITLE
Adding Herman and Gary to the Advisory Board

### DIFF
--- a/content/consortium/_index.md
+++ b/content/consortium/_index.md
@@ -40,6 +40,5 @@ Consortium members *partner* to advance force fields. Thus, the Consortium is a 
 - Alireza Shabani (Qulab)
 - Xinjun Hou (Pfizer)
 - Doree Sitkoff (Bristol-Myers Squibb)
-- Gary Tresadern (Janssen)
 - Herman Van Vlijmen (Janssen)
 - Additional members to be disclosed following legal approval

--- a/content/consortium/_index.md
+++ b/content/consortium/_index.md
@@ -40,4 +40,6 @@ Consortium members *partner* to advance force fields. Thus, the Consortium is a 
 - Alireza Shabani (Qulab)
 - Xinjun Hou (Pfizer)
 - Doree Sitkoff (Bristol-Myers Squibb)
+- Gary Tresadern (Janssen)
+- Herman Van Vlijmen (Janssen)
 - Additional members to be disclosed following legal approval


### PR DESCRIPTION
Adding Gary Tresadern and Herman Van Vlijmen from Janssen to the Advisory Board list

![image](https://user-images.githubusercontent.com/32760282/59035713-dc2e9880-883b-11e9-932a-953be49881bd.png)
