### PR TITLE
Fixing the broken Github link to Chemper

### DIFF
--- a/content/news/aug-2019-meeting-announcement.md
+++ b/content/news/aug-2019-meeting-announcement.md
@@ -50,7 +50,7 @@ Time         | Event &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbs
 
 Time         | Event  
 -------------|-------
-8.30 - 9.30	| Advisory Board meeting_ (closed)
+8.30 - 9.30	| _Advisory Board meeting_ (closed)
 9.30 - 10.30	| Future parameterization perspective: Plan for Year 2 and beyond
 10.30 - 11.00 | **_Coffee break_**
 11.00 - 11.45	| Energies and Forces from Machine Learning (O. Isayev)

--- a/data/publications/publications.yaml
+++ b/data/publications/publications.yaml
@@ -8,7 +8,7 @@
     url: https://chemrxiv.org/articles/ChemPer_An_Open_Source_Tool_for_Automatically_Generating_SMIRKS_Patterns/8304578
     license: "CC BY 4.0"
     date: 2019-06-20
-  github: https://github.com/MobleyLab/chemper
+  github: MobleyLab/chemper
 - title: "Systematic Optimization of Water Models Using Liquid/Vapor Surface Tension Data"
   authors: "Yudong Qiu, Paul S. Nerenberg, Teresa Head-Gordon, Lee-Ping Wang"
   summary: This work investigates whether experimental surface tension measurements, which are less sensitive to quantum and self-polarization corrections, are able to replace the usual reliance on the heat of vaporization as experimental reference data for fitting force field models of molecular liquids.


### PR DESCRIPTION
Fixing broken link for Chemper.

Fixing italics in the Aug meeting announcement (Advisory Board meeting).