### PR TITLE
Fixing alphabetical order in Advisory Board listing

### DIFF
--- a/content/consortium/_index.md
+++ b/content/consortium/_index.md
@@ -34,11 +34,11 @@ Consortium members *partner* to advance force fields. Thus, the Consortium is a 
 - Ian Craig (BASF), Vice Chair
 - Thomas Fox (Boehringer-Ingelheim)
 - Jérôme Hert (Roche)
+- Xinjun Hou (Pfizer)
 - Daniel Kuhn (Merck KGaA), Chair
 - Katharina Meier (Bayer)
 - Arjun Narayanan (Vertex), Secretary
 - Alireza Shabani (Qulab)
-- Xinjun Hou (Pfizer)
 - Doree Sitkoff (Bristol-Myers Squibb)
 - Herman Van Vlijmen (Janssen)
 - Additional members to be disclosed following legal approval


### PR DESCRIPTION
Moving Xinjun Hou after Jerome Hert in the Advisory Board listing on the website.

![image](https://user-images.githubusercontent.com/32760282/61160836-1d673780-a4cf-11e9-9023-c78cc65e2acf.png)
