### PR TITLE
Advisory Board meeting minutes 2019-07-17

### DIFF
--- a/content/consortium/minutes/2019-05-15-minutes.md
+++ b/content/consortium/minutes/2019-05-15-minutes.md
@@ -14,8 +14,6 @@ The minutes are summarized as follows:
 
 ### Open Forcefield Advisory Board Meeting Minutes – May 15, 2019
 
-2019/05/15 Advisory Board Meeting Minutes
-
 
 **Overview** of the [roadmap](https://openforcefield.org/science/downloads/roadmap/roadmap-graphic-may-2019-update.pdf) for the remaining time of Year 1 and the accomplishments made so far (J. Chodera).
 
@@ -73,5 +71,3 @@ The minutes are summarized as follows:
 - Involvement in the subgroup meetings - a visible schedule to make it easier for interested parties to join. In the meantime, contact Karmen to provide more information;
 
 - Better accessibility of slides and data-- Zenodo Community about to be formed to address this problem.
-
-

--- a/content/consortium/minutes/2019-06-13-minutes.md
+++ b/content/consortium/minutes/2019-06-13-minutes.md
@@ -14,7 +14,6 @@ The minutes are summarized as follows:
 
 ### Open Forcefield Advisory Board Meeting Minutes – June 13, 2019
 
-2019/06/113 Advisory Board Meeting Minutes
 
 **First optimized force field** (D. Mobley):
 

--- a/content/consortium/minutes/2019-07-17-minutes.md
+++ b/content/consortium/minutes/2019-07-17-minutes.md
@@ -1,0 +1,39 @@
+---
+date: "2019-07-23T00:00:00+00:00"
+title: "Jul 17, 2019 Advisory Board Meeting"
+tags: ["Open Force Field Consortium", "Advisory Board", "minutes"]
+categories: ["Advisory Board Meeting Minutes"]
+draft: false
+description: "Meeting minutes"
+weight: 10
+author: "Karmen Condic-Jurkic"
+---
+
+The [Open Force Field Consortium Advisory Board](https://openforcefield.org/consortium/) met on July 17, 2019.
+The minutes are summarized as follows:
+
+### Open Forcefield Advisory Board Meeting Minutes – July 17, 2019
+
+
+The Advisory Board format was slightly changed on this occasion -  the report about the latest development was sent before the meeting to leave more time for questions and discussions. We will test this new format during the next few meetings. Feedback and comments are welcome!
+
+**OFF Toolkit:** Release of the OFF Toolkit 0.5.0 version has been delayed due to certain difficulties with the implementation of GBSA model and prioritization of developer time to technical issues and toolkit capabilities critical for release-1.
+
+**Datasets:**
+
+* D. Mobley gave an additional update on the progress made on the molecule sets going through the QC pipeline, including the progress with torsion and Hessian computations, which are all well on their way.
+* Some molecules are missing BCCs, but working around it at the moment and it should not be an issue for the planned release.
+* Currently working on setting up the boron set for the QC pipeline.
+* RDKit was recommended to generate reasonable starting conformers for geometry optimizations for structures with boron and other elements not well covered by the current force fields, after the question was asked about the tools that might help with that.
+* J. Chodera noted that the progress with the molecule sets has been much faster than expected and invited Partners to submit additional molecule sets, if they wish to do so. The best format to submit molecule set is isomeric SMILES, which are preferred over SDF or other similar formats.
+<br/><br/>
+
+**Release-1:**
+
+* An [update](https://openforcefield.org/science/updates/2019-07-16-release-1/) for the planned release of the first optimized force field has been posted on the website.
+* D. Mobley reported that they are working on some interesting chemistry and impropers and checking if better treatment of impropers has a significant impact on the force field performance.
+* At the moment, changing periodicities for torsions is out of scope for release-1, but some spot refitting will be done in cases where the usual fitting procedure fails.
+* The beta version of the optimized force field (release-1) is planned to be ready by the end of August and validated during September. Everyone is welcome to use the beta version immediately upon release.
+<br/><br/>
+
+**Logo slide:** K. Condic-Jurkic to check with D. Kuhn about progress made on the logo slide approval.


### PR DESCRIPTION
- Posting the meeting minutes from Advisory Board meeting on July 17, 2019
- Removing a superfluous line with dates from the minutes taken during the meeting in May and June (copied from the notes)


![image](https://user-images.githubusercontent.com/32760282/61751190-78254c80-ad75-11e9-8923-a3802f13c75e.png)
