### PR TITLE
Replacing Virginia Burger with Shuai Liu as XtalPi reprepresentative

### DIFF
--- a/content/consortium/_index.md
+++ b/content/consortium/_index.md
@@ -30,12 +30,12 @@ Consortium members *partner* to advance force fields. Thus, the Consortium is a 
 
 
 ### Advisory Board
-- Virginia Burger (XtalPi)
 - Ian Craig (BASF), Vice Chair
 - Thomas Fox (Boehringer-Ingelheim)
 - Jérôme Hert (Roche)
 - Xinjun Hou (Pfizer)
 - Daniel Kuhn (Merck KGaA), Chair
+- Shuai Liu (XtalPi)
 - Katharina Meier (Bayer)
 - Arjun Narayanan (Vertex), Secretary
 - Alireza Shabani (Qulab)


### PR DESCRIPTION
Shuai Liu will replace Virginia Burger as the XtalPi representative on the Advisory Board

![image](https://user-images.githubusercontent.com/32760282/62381829-4d2bbd00-b51a-11e9-8414-448d11f9e794.png)
