### PR TITLE
Add initial Scientific Advisory Board members

### DIFF
--- a/content/science/_index.md
+++ b/content/science/_index.md
@@ -42,8 +42,8 @@ The Board convenes two virtual meetings per year to advise on various aspects of
 
 The current Scientific Advisory Board consists of scientists engaged within the force field development and biomolecular simulation software communities:
 
-* Carlos Simmerling (Stony Brook University)
-* Sereina Riniker (ETH Zurich)
-* Junmei Wang (University of Pittsburgh)
-* Teresa Head-Gordon (University of California, Berkeley)
-* David Case (Rutgers)
+* [Carlos Simmerling](https://www.stonybrook.edu/commcms/chemistry/faculty/simmerling.carlos.html) (Stony Brook University) [[lab website](http://laufercenter.stonybrook.edu/simmerling/Home)]
+* [Sereina Riniker](TIwNjc3.TGlzdC8xNDkzLC04NTQ1MTI4MDM=.html) (ETH Zurich) [[lab website](https://riniker.ethz.ch/)]
+* [Junmei Wang](https://www.pharmacy.pitt.edu/directory/profile.php?profile=1639) (University of Pittsburgh) [[lab website](https://mulan.pharmacy.pitt.edu/)]
+* [Teresa Head-Gordon](https://chemistry.berkeley.edu/faculty/chem/teresa-head-gordon) (University of California, Berkeley) [[lab website](https://thglab.berkeley.edu/)]
+* [David Case](https://rutchem.rutgers.edu/people/faculty-bio/130-case-david) (Rutgers) [[lab website](http://casegroup.rutgers.edu/)]

--- a/content/science/_index.md
+++ b/content/science/_index.md
@@ -33,4 +33,17 @@ Roadmap Presentation at January 2019 Consortium Workshop [[DOI]](http://doi.org/
 - QCFractal User Group meetings take place every Friday at 3.15 pm EDT;
 - Charge model meetings take place at irregular intervals.
 
-Please contact Karmen at info@openforcefield.org or karmen.condic-jurkic@choderalab.org if you are interested to participate in any of the listed meetings.
+Please contact Karmen Čondić-Jurkić at [info@openforcefield.org](mailto:info@openforcefield.org) or [karmen.condic-jurkic@choderalab.org](mailto:karmen.condic-jurkic@choderalab.org) if you are interested to participate in any of the listed meetings.
+
+# Scientific Advisory Board
+
+The Scientific Advisory Board provides valuable input to help guide the Open Force Field Initiative toward the most relevant engineering and science efforts that will empower members of the biomolecular simulation and force field development communities.
+The Board convenes two virtual meetings per year to advise on various aspects of the overall Initiative and receives invitations to join our two in-person meetings per year.
+
+The current Scientific Advisory Board consists of scientists engaged within the force field development and biomolecular simulation software communities:
+
+* Carlos Simmerling (Stony Brook University)
+* Sereina Riniker (ETH Zurich)
+* Junmei Wang (University of Pittsburgh)
+* Teresa Head-Gordon (University of California, Berkeley)
+* David Case (Rutgers)


### PR DESCRIPTION
This PR adds the initial set of Scientific Advisory Board members to the Science page.
![image](https://user-images.githubusercontent.com/3656088/62535039-51b9e380-b842-11e9-8b54-e4cfa0c359e4.png)
We can always improve this later, and possibly migrate this data to a YAML file to allow us to more flexibly render/relocate it in the future.