### PR TITLE
Add "Alumni" subset for members

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ ORCID: 0000-0003-0542-119X
 twitter: jchodera
 github: jchodera
 ```
-where `role` for active members can be `Researcher`, `Advisor`, `Software Scientist`, or `Primary Investigator`.
-Inactive members can be either `Alumnus` or `Alumna`.
+where `role` for active members can be `Researcher`, `Advisor`, `Software Scientist`, `Primary Investigator`, or `alum`.
 
 ### Adding new publications
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ ORCID: 0000-0003-0542-119X
 twitter: jchodera
 github: jchodera
 ```
-where `role` can be `Researcher`, `Advisor`, `Software Scientist`, or `Primary Investigator`.
+where `role` for active members can be `Researcher`, `Advisor`, `Software Scientist`, or `Primary Investigator`.
+Inactive members can be either `Alumnus` or `Alumna`.
 
 ### Adding new publications
 

--- a/data/members/Andrea_Rizzi.yaml
+++ b/data/members/Andrea_Rizzi.yaml
@@ -1,5 +1,5 @@
 name: Andrea Rizzi
-role: Researcher
+role: Alumnus
 lab: Chodera lab
 title: Computational Biology and Medicine Graduate Student
 institution: Sloan Kettering Institute

--- a/data/members/Caitlin_Bannan.yaml
+++ b/data/members/Caitlin_Bannan.yaml
@@ -1,5 +1,5 @@
 name: Caitlin C. Bannan
-role: Alumna
+role: alum
 lab: Mobley lab
 title: Chemistry Graduate Student and MolSSI Fellow
 institution: University of California, Irvine

--- a/data/members/Caitlin_Bannan.yaml
+++ b/data/members/Caitlin_Bannan.yaml
@@ -1,5 +1,5 @@
 name: Caitlin C. Bannan
-role: Researcher
+role: Alumna
 lab: Mobley lab
 title: Chemistry Graduate Student and MolSSI Fellow
 institution: University of California, Irvine

--- a/data/members/Katy_Kellett.yaml
+++ b/data/members/Katy_Kellett.yaml
@@ -1,5 +1,5 @@
 name: Katy Kellett
-role: Alumna
+role: alum
 lab: Gilson lab
 title: Postdoctoral Researcher
 institution: University of California, San Diego

--- a/data/members/Katy_Kellett.yaml
+++ b/data/members/Katy_Kellett.yaml
@@ -1,5 +1,5 @@
 name: Katy Kellett
-role: Researcher
+role: Alumna
 lab: Gilson lab
 title: Postdoctoral Researcher
 institution: University of California, San Diego

--- a/data/members/Kenneth_Kroenlein.yaml
+++ b/data/members/Kenneth_Kroenlein.yaml
@@ -1,5 +1,5 @@
 name: Kenneth Kroenlein
-role: Advisor
+role: Alumnus
 title: Group Leader
 institution: NIST Thermodynamics Research Center
 img: ken-kroenlein.jpg

--- a/data/members/Kenneth_Kroenlein.yaml
+++ b/data/members/Kenneth_Kroenlein.yaml
@@ -1,5 +1,5 @@
 name: Kenneth Kroenlein
-role: Alumnus
+role: alum
 title: Group Leader
 institution: NIST Thermodynamics Research Center
 img: ken-kroenlein.jpg

--- a/themes/kube/layouts/partials/person.html
+++ b/themes/kube/layouts/partials/person.html
@@ -2,7 +2,7 @@
   <img src=img/{{ .img }}>
 </div>
 <div class="col col-9">
-  <h4><b>{{ .name }}</b> ({{ .role }})
+  <h4><b>{{ .name }}</b> {{ if ne .status "alum" }} ({{ .role }}) {{ end }}
   {{ with .twitter }} <a href="http://twitter.com/{{ . }}"><img width="20" src="img/twitter.png"></a> {{ end }}
   {{ with .github }} <a href="http://github.com/{{ . }}"><img width="20" src="img/github.png"></a> {{ end }}
   </h4>

--- a/themes/kube/layouts/section/members.html
+++ b/themes/kube/layouts/section/members.html
@@ -87,7 +87,7 @@
 
 <ul>
 {{ range $.Site.Data.members }}
-  {{ if or (eq .status "Alumnus") (eq .status "Alumna") }}
+  {{ if eq .status "alum" }}
   <div class="row gutters">
     {{ partial "person" . }}
   </div>

--- a/themes/kube/layouts/section/members.html
+++ b/themes/kube/layouts/section/members.html
@@ -81,6 +81,20 @@
 {{ end }}
 </ul>
 
+<!-- Alumni -->
+
+<h2>Alumni</h2>
+
+<ul>
+{{ range $.Site.Data.members }}
+  {{ if or (eq .status "Alumnus") (eq .status "Alumna") }}
+  <div class="row gutters">
+    {{ partial "person" . }}
+  </div>
+  {{ end }}
+{{ end }}
+</ul>
+
 <!-- Researchers -->
 
 </div>


### PR DESCRIPTION
Setting `role` to `Alumnus` or `Alumna` in the member YAML files in `data/members/` will now move the individual to an "Alumni" section of the Members page.

This hasn't been locally tested yet.