### PR TITLE
Jobs page update

### DIFF
--- a/content/jobs/_index.md
+++ b/content/jobs/_index.md
@@ -16,14 +16,14 @@ We aim to publish frequently and openly---a sample of existing publications can 
 
 The [Open Force Field Initiative](http://openforcefield.org) is a multi-investigator collaboration that aims to build new, quantitatively accurate molecular mechanics force fields supported by a modern software infrastructure, built on principles of open source, open data, and open science. More about their scientific goals and plans can be found in the Open Force Field Initiative [Executive Summary](https://openforcefield.org/science/downloads/roadmap/open-forcefield-summary.pdf) or [Roadmap](https://openforcefield.org/science/downloads/roadmap/open-forcefield-plan.pdf).
 
-### Desired qualifications
+#### Desired qualifications
 
 * Experience with the theory and practice of atomistic biomolecular simulation using molecular mechanics force fields
 * Comfortable with the Python programming language
 * Exposure to [modern open source software development practices](https://github.com/choderalab/software-development) ([GitHub](http://github.org), unit tests, continuous integration)
 * Good multidisciplinary teamwork and communication skills
 
-### Bonus qualifications (nice to have, but not required!)
+#### Bonus qualifications (nice to have, but not required!)
 
 * Experience with force field parameter fitting for small organic molecules
 * Experience with quantum chemical calculations in general, and [psi4](http://www.psicode.org/) in particular
@@ -33,7 +33,7 @@ The [Open Force Field Initiative](http://openforcefield.org) is a multi-investig
 * Experience with probabilistic programming languages (e.g. [PyMC](https://github.com/pymc-devs), [TensorFlow Probability](https://www.tensorflow.org/probability/overview), [Pyro](http://pyro.ai/)) and/or machine learning frameworks like [TensorFlow](http://tensorflow.org) or [pytorch](https://pytorch.org/)
 * Experience with cheminformatics or computer-aided drug discovery
 
-### Location
+#### Location
 
 Open Force Field Initiative postdocs will generally have flexibility in location, with potential sites including the participating investigator laboratories:
 
@@ -43,13 +43,13 @@ Open Force Field Initiative postdocs will generally have flexibility in location
 * [David L. Mobley](http://mobleylab.org) (UCI, Irvine, CA)
 * [Michael R. Shirts](https://www.colorado.edu/lab/shirtsgroup/) (University of Colorado, Boulder, CO)
 
-### Appointment duration
+#### Appointment duration
 
 The initial appointment will be for one year, with the potential for extension to multiple years to focus on other aspects of force field science and engineering. Position is pending final approval of funding.
 
-### Applying
+#### Applying
 
-Interested candidates should email an application to `openforcefield@choderalab.org` with the subject line “Postdoc application” that includes:
+Interested candidates should email an application to `info@openforcefield.org` with the subject line “Postdoc application” that includes:
 
 * a cover letter explaining your motivation, background, and qualifications for the position
 * a detailed Curriculum Vitae (including a list of publications)
@@ -57,49 +57,22 @@ Interested candidates should email an application to `openforcefield@choderalab.
 
 ---
 
-<a id="janssen-postdoc"></a>
+<a id="postdoc-labs"></a>
 
-## Janssen Distinguished Open Force Field Consortium Postdoc
+## Other Available Postdoc Positions
 
-[Open Force Field Consortium](https://openforcefield.org/consortium/) Partner [Janssen Research & Development](https://www.jnj.com/) is hiring a postdoc to work on open source, open science [Open Force Field Consortium](https://openforcefield.org/consortium/) projects!
-The position will be supervised by [Open Force Field Investigators](https://openforcefield.org/members/) and co-mentored by talented J&J computational chemists, including [Gary Tresadern](https://scholar.google.es/citations?user=uMYJoIkAAAAJ&hl=en).
-The position is located at the [J&J Beerse site in Belgium](https://www.janssen.com/sites/www_janssen_com_belgium/files/pdf/150310%20JanssenBelgiumBrochure_ENGLISH_DUTCH_FRENC.pdf).
+#### [Postdoc position available in the Mobley lab](https://mobleylab.org/2019/11/18/postdoc-position-available-in-the-mobley-lab/)
 
-Apply via the J&J site here: https://jobs.jnj.com/jobs/1905719143W?lang=en-us
+Interested in improving predictive modeling of biomolecular interactions? [We](https://mobleylab.org/) seek a postdoc who will work on binding free energy methods and applications (likely including our BLUES method for enhanced sampling of ligand binding modes), as well as with the Open Force Field Initiative (OpenFF, openforcefield.org) on testing and improving biomolecular force fields, though this is not an OpenFF position. The candidate may also get involved with the SAMPL series of blind challenges, helping to drive progress in the field by facilitating comparisons of the latest methods on cutting-edge datasets in blind challenges we help design.
 
-(Text of ad reprinted below)
+The ideal candidate will have a strong background in scientific software development, including with Python, experience with molecular dynamics simulations and method development (free energy calculations would be an additional plus!) and significant experience working as part of a team.
 
-Requisition ID: [1905719143W](https://jobs.jnj.com/jobs/1905719143W?lang=en-us)
+To apply, please send a cover letter explaining your interest in the position and your relevant background, along with a CV which also contains contact information for at least three references to me at `dmobley+postdoc@gmail.com`. This position will start as soon as a suitable candidate can be found, but applications should be received before mid-December, 2019.
 
-Janssen Research & Development seeks to drive innovation and deliver transformational medicines for the treatment of diseases in six therapeutic areas: neuroscience, cardiovascular diseases and metabolism, infectious diseases, immunology, oncology and pulmonary hypertension. In these areas, Janssen aims to address and solve unmet medical needs through the development of small and large molecules, as well as vaccines. The Janssen campus in Beerse (Belgium) has a unique ecosystem covering the complete drug development life cycle, with all capabilities from basic science to market access on one campus. The integrated environment of our campus gives our people the chance to experience many different aspects of drug development throughout their career. It has a successful track record of over sixty years of drug discovery and development and is one of the most important innovation engines of the Janssen group worldwide.
+#### [Two postdoc positions available in the Shirts lab](https://www.colorado.edu/lab/shirtsgroup/available-positions)
 
-Developing innovative therapeutics to treat diseases like Alzheimer’s disease, various types of cancers and infectious diseases like Hepatitis B, influenza is our passion. In this endeavor, we are seeking to recruit new talent for the comprehensive analyses of high-dimensional datasets using state-of-the-art data science methods applied to drug discovery programs. The position will be opened on the Beerse campus, which is the flagship R&D center for small molecules within Janssen, investing over 1 billion euros each year in R&D.
+[The Shirts group](https://www.colorado.edu/lab/shirtsgroup/) has two job openings:
 
-We are looking for a highly skilled and motivated **computational chemist** for the position of **PostDoc – Open Force Field, Computational Chemistry**, at our Beerse, Belgium site. The position is part of the Open Force Field Consortium, funded by an alliance of pharmaceutical and biotech companies aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort. The Open Force Field Initiative is a multi-investigator collaboration that aims to build new, quantitatively accurate molecular mechanics force fields supported by a modern software infrastructure, built on principles of open source, open data, and open science. Collaborating academic laboratories include: Michael K. Gilson (UCSD, La Jolla, CA), John D. Chodera (MSKCC, New York City, NY), Lee-Ping Wang (UCD, Davis, CA), David L. Mobley (UCI, Irvine, CA), or Michael R. Shirts (University of Colorado, Boulder, CO). Janssen is part of this consortium and we seek a skilled PostDoc to contribute to this exciting collaborative project.
+1. One postdoctoral position is to develop guidelines, based on fundamental physical principles, by which short nonbiological heteropolymers with sequence specificity can fold into secondary structure elements. This research will also help study what governs the relative stability between these allowed secondary structural elements. These initial studies will pave the way for more extensive and realistic modeling of the proposed heteropolymers, working with our experimental collaborators. This research effort is intended to build tools and theories for crafting human-engineered foldameric materials with a much larger range of properties and functions that occur in naturally occurring biological heteropolymers such as proteins. See the application page for more details: https://jobs.colorado.edu/jobs/JobDetail/Postdoctoral-Associate/22277.
 
-### Responsibilities of the PostDoc Scientist will include:
-
-* Develop and execute clear computational programming strategies contributing to the collaboration.
-* Work In close collaboration with the external collaborating groups to develop the force field via its different working groups
-* Test developments of the force field on data originating from Janssen or the public domain
-
-### Qualifications
-
-* Experience with the theory and practice of atomistic biomolecular simulation using molecular mechanics force fields
-* Comfortable with the Python programming language
-* Exposure to modern open source software development practices (GitHub, unit tests, continuous integration)
-* Good multidisciplinary teamwork and communication skills
-* Bonus qualifications (nice to have, but not required!):
-* Experience with force field parameter fitting for small organic molecules
-* Experience with quantum chemical calculations in general, and psi4 in particular
-* Experience with high-performance computing clusters and/or cloud computing
-* Knowledge of organic chemistry
-* Experience with the open-source GPU-accelerated molecular simulation Python library OpenMM
-* Experience with probabilistic programming languages (e.g. PyMC, tensorflow.Probability, Pyro) and/or machine learning frameworks like TensorFlow
-* Experience with cheminformatics or computer-aided drug discovery
-
-**Appointment:** The position will be for two years.
-
-**Open Force Field Initiative:** To find out more about the Open Force Field Initiative, visit http://openforcefield.org.
-
-Up to 10% travel may be required
+2. A second postdoctoral position is to study the structure of nanostructured membranes formed by the self-assembly and polymerization of amphiphilic molecules as well as the mechanical properties of these membranes. These structural studies will be accompanied by study of the transport of small molecules in the nanochannels of these membranes. The mechanistic insights obtained in these studies will be used in collaboration with experimentalists to design and test new membranes that have high, chemically specific rejection of a range of solutes while maintaining high permeability of water. See the application page for more details: https://jobs.colorado.edu/jobs/JobDetail/Postdoctoral-Associate/22282.


### PR DESCRIPTION
* Change the contact for OpenFF postdoc from `openforcefield@choderalab.org` to `info@openforcefield.org`
* Add job descriptions for the Mobley and Shirts groups

![image](https://user-images.githubusercontent.com/32760282/69381427-be86ab80-0c82-11ea-809b-839de650cb2a.png)
