### PR TITLE
Expanding the QM job description and removing other ads

### DIFF
--- a/content/jobs/_index.md
+++ b/content/jobs/_index.md
@@ -9,36 +9,26 @@ layout: faq
 
 ## **Open Force Field Initiative Postdoc**
 
-The **Open Force Field Initiative** is seeking talented postdoctoral fellows to work on the development of modern toolkits and new methods for building next-generation molecular mechanics force fields. This position will focus on generation, curation and management of quantum chemistry datasets, benchmarking studies, and assistance with force field optimization. There is a possibility to expand this role towards substantial contributions to development of QCArchive infrastructure, depending on the candidate's preferences and software skills. [QCArchive](https://qcarchive.molssi.org/) enables computing and storing of quantum chemistry data and it is powered by modular and open source infrastructure. Currently, MolSSI server stores the largest publicly available collection of quantum chemistry data.
+The [Open Force Field Initiative](http://openforcefield.org) is seeking a talented postdoctoral fellow to work on the development of modern toolkits and new methods for building next-generation molecular mechanics force fields. In particular, we are seeking for someone who:
+
+* understands quantum chemistry methods and physical organic chemistry,
+* can help us make decisions about how we generate the training sets for our force fields, and
+* is passionate about open source software and open science.
+
+The candidate is expected to lead our efforts around generation, curation and management of quantum chemistry datasets. Our QC data is publicly accessible on the [MolSSI QCArchive](https://qcarchive.molssi.org/), but we would like to make this data more accessible and easier to (re)use, and achieving this goal would be one of the duties associated with this role. We also expect the candidate to assist with force field optimization processes and benchmarking studies, perform scientific studies to inform future decisions in force field development, and of course, work together with the entire team to iteratively improve our force fields and infrastructure. As mentioned above, the candidate will also frequently interact with MolSSI scientists supporting QCArchive. [QCArchive](https://qcarchive.molssi.org/) enables computing and storing of quantum chemistry data and it is powered by modular and open source infrastructure. Depending on the candidate’s interests, the position could also potentially include contributions to QCArchive infrastructure development and maintenance. The candidate will have a reasonable amount of independence in their work, especially in their core area of expertise, although a certain level of coordination is required in this collaborative project.
 <br>
 <br>
-The effort has been primarily funded by the Open Force Field Consortium and since March 2020, the Initiative has been awarded the NIH grant focused on development of accurate biomolecular force fields [Open Force Field Consortium](https://openforcefield.org/consortium/) is an [alliance of pharmaceutical and biotech companies](https://openforcefield.org/news/introducing-the-consortium/) aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort.
-Postdocs will work closely with other researchers in the Initiative, multiple academic Initiative PIs, industry Partner scientific collaborators, and software scientists at [MolSSI](http://molssi.org) to develop and apply new algorithms and modern open source software infrastructure for building high quality biomolecular force fields.
-We aim to publish frequently and openly and a sample of existing publications can be found [here](http://openforcefield.org/publications).
-The [Open Force Field Initiative](http://openforcefield.org) is a multi-investigator collaboration that aims to build new, quantitatively accurate molecular mechanics force fields supported by a modern software infrastructure, built on principles of open source, open data, and open science. More about their scientific goals and plans can be found in the Open Force Field Initiative [Executive Summary](https://openforcefield.org/science/downloads/roadmap/open-forcefield-summary.pdf).
-
-#### Desired qualifications
-
-* Experience with theory and application of quantum chemistry methods
-* Comfortable with the Python programming language
-* Exposure to [modern open source software development practices](https://github.com/choderalab/software-development) ([GitHub](http://github.org), unit tests, continuous integration)
-* Good multidisciplinary teamwork and communication skills
-
-#### Bonus qualifications (nice to have, but not required!)
-
-* Experience with force field parameter fitting for small organic molecules
-* Experience with cheminformatics or computer-aided drug discovery
-* Knowledge of physical organic chemistry
-* Experience with high-performance computing clusters and/or cloud computing
-* Experience with [Psi4](http://www.psicode.org/) suite
-* Experience with the open-source GPU-accelerated molecular simulation Python library [OpenMM](http://openmm.org)
-* Experience with probabilistic programming languages (e.g. [PyMC](https://github.com/pymc-devs), [TensorFlow Probability](https://www.tensorflow.org/probability/overview), [Pyro](http://pyro.ai/)) and/or machine learning frameworks like [TensorFlow](http://tensorflow.org) or [PyTorch](https://pytorch.org/)
-* Experience with databases and distributed computing
-
+Many aspects of this position can be tailored around the candidate’s expertise and ambitions and we would encourage everyone excited about application of quantum chemistry, force field development and open science to apply!
+<br>
+<br>
+**About us:** We are a [distributed team](https://openforcefield.org/members/) of PhD students, postdocs and software scientists led by 5 academic PIs -- Mike Gilson, David Mobley, Lee-Ping Wang, Michael Shirts, and John Chodera. The effort has been primarily funded by the Open Force Field Consortium and since March 2020, the Initiative has been awarded a 5-year NIH grant focused on development of accurate biomolecular force fields. The [Open Force Field Consortium](https://openforcefield.org/consortium/) is an [alliance of pharmaceutical and biotech companies](https://openforcefield.org/news/introducing-the-consortium/) aiming to advance the state of force fields for biomolecular simulation and design through an open collaborative effort. In our organization, the postdocs and PhD students do research and exploratory work using our tools/data, while a team of software scientists (holding PhDs in biomolecular research) support these researchers by doing long-term project planning and developing [our software ecosystem](https://openforcefield.org/consortium/software/). More about our scientific goals and plans can be found in the Open Force Field Initiative [Executive Summary](https://openforcefield.org/science/downloads/roadmap/open-forcefield-summary.pdf).
+<br>
+<br>
+The Open Force Field Initiative is built on principles of open source, open data, and open science. We aim to publish frequently and openly and a sample of existing publications can be found [here](http://openforcefield.org/publications). All of our software is released under permissive licenses and we try to share all data produced in our efforts. We also release frequent scientific updates on our website and on GitHub, and we have yearly meetings with our pharma partners to give updates on our progress. In addition to this and other events, the OpenFF Initiative provides access to a large network of young and established scientists in computational chemistry from academia and industry, offering access to both academic and industry career paths. Supporting all team members in achieving their career goals is taken seriously by all OpenFF PIs.
 
 #### Location
 
-This position will be hosted by the [Mobley lab](http://mobleylab.org) as UC Irvine, CA. However, there is a certain amount of flexibility around location and the Open Force Field postdocs can be hosted at any of the participating investigator sites:
+The preferred physical location for this position would be the [Mobley lab]((http://mobleylab.org) as UC Irvine, CA. However, we can offer a certain amount of flexibility around location and the Open Force Field postdocs can be hosted at any of the participating investigator sites:
 
 * [Michael K. Gilson](http://gilson.cloud.ucsd.edu/) (UCSD, La Jolla, CA)
 * [John D. Chodera](http://choderalab.org) (MSKCC, New York City, NY)
@@ -61,76 +51,25 @@ Interested candidates should fill out this [form](https://forms.gle/Jk46ZEbWwXKy
 
 *Please note that you can only upload files if you have a valid Google account. Alternatively, please email your CV and cover letter to `info@openforcefield.org` with the subject line "Job Application Files" after filling out the form.*
 
----
-<a id="initiative-software-scientist"></a>
+#### Desired qualifications
+
+* Experience with theory and application of quantum chemistry methods
+* Comfortable with the Python programming language
+* Exposure to [modern open source software development practices](https://github.com/choderalab/software-development) ([GitHub](http://github.org), unit tests, continuous integration)
+* Good multidisciplinary teamwork and communication skills
+
+#### Bonus qualifications (nice to have, but not required!)
+
+* Experience with force field parameter fitting for small organic molecules
+* Experience with cheminformatics or computer-aided drug discovery
+* Knowledge of physical organic chemistry
+* Experience with high-performance computing clusters and/or cloud computing
+* Experience with [Psi4](http://www.psicode.org/) suite
+* Experience with the open-source GPU-accelerated molecular simulation Python library [OpenMM](http://openmm.org)
+* Experience with probabilistic programming languages (e.g. [PyMC](https://github.com/pymc-devs), [TensorFlow Probability](https://www.tensorflow.org/probability/overview), [Pyro](http://pyro.ai/)) and/or machine learning frameworks like [TensorFlow](http://tensorflow.org) or [PyTorch](https://pytorch.org/)
+* Experience with databases and distributed computing
 
 
+## Other opportunities
 
-## **Other Available Positions**
-
-<a id="chodera-postdocs"></a>
-
-## [Postdoc positions available in the Chodera lab](http://www.choderalab.org/jobs)
-
-There are several postdoc positions available for joint projects between the [Chodera lab](http://www.choderalab.org/) based [MSKCC](http://mskcc.org/) in New York and the [Volkamer group](https://physiologie-ccm.charite.de/en/research_at_the_institute/team_volkamer/) at the [Charité](https://www.charite.de/en/) in Berlin, and [Shantenu Jha](http://radical.rutgers.edu/people/shantenu-jha) at Brookhaven National Lab / Rutgers University.
-
-<a id="chodera-bayer-postdoc"></a>
-
-**1. Bayer sponsored postdoctoral fellows (New York / Berlin)**
-
-The [Chodera lab](http://www.choderalab.org/) in New York and the [Volkamer group](https://physiologie-ccm.charite.de/en/research_at_the_institute/team_volkamer/) in Berlin are seeking talented postdoctoral fellows to work at the interface of structure-informed machine learning and alchemical free energy calculations as part of an exciting new collaboration between these two labs. This project seeks to develop an integrated framework for utilizing both state-of-the-art machine learning approaches and free energy calculations to exploit structural data, assay data, and scalable computing resources to predict the impact of point mutations on the binding of small molecule kinase inhibitors, with a goal toward expanding the utility of clinical kinase inhibitors.
-
-The positions are part of a collaboration with Bayer AG, Germany, pending final confirmation of funding in duration of 2 years. We are seeking candidates to start as soon as possible at our locations in New York and Berlin.
-
-**Applications:** Interested candidates are invited to send a pre-application to <einstein@choderalab.org> with the subject line “Postdoc application” that includes:
-
-* a cover letter explaining your motivation, background, and qualifications for the position
-* a detailed Curriculum Vitae (including a list of publications)
-* contact information of two references
-
-If you are applying for the position in New York, please change the subject line to "Postdoc application: NYC". More information about these positions and how to apply can be found [here](http://www.choderalab.org/jobs).
-
-<a id="chodera-brookhaven-postdoc-staffsci"></a>
-
-**2. HPC postdoctoral fellow or staff scientist (Brookhaven National Lab)**
-
-The Chodera lab and Brookhaven National Lab are hiring a postdoc or staff scientist to work at the intersection of  software development and high-performance computing, spearheading the development of software infrastructure for scalable alchemical free energy calculations and machine learning. This is a 3-year position with an option for extension and it sits at the interface of high-performance computing, machine learning and computational science. Find more details about this position [here](http://www.choderalab.org/jobs).
-
-**Applications:** Interested candidates should send a cover letter and CV to <postdoc@choderalab.org> with the subject line “BNL Postdoc Position” or “BNL Staff Scientist Position”.
-
-
-<a id="entos"></a>
-
-## Cloud Engineer at Entos
-
-**Company Background**
-
-[Entos](https://www.entos.info/) was founded in 2019 by faculty from Caltech and the University of Bristol and is situated at the interface of quantum chemistry, machine learning, and drug discovery. We seek to bring quantum simulation to real-world problems and disrupt entire industries along the way. Our team is currently small, but mighty and rapidly growing. We are committed to building an inclusive work environment at Entos, where a diverse group of talented people work together to create awesome technologies. If you have the curiosity, passion, and collaborative spirit, join us and let’s change the world together!
-
-**Company Background**
-
-We are looking for a talented and motivated [Cloud Engineer](entos_cloud_engineer.pdf) who is excited about working on cloud computing technologies to build automated high-performance physics- and machine-learning- based simulation solutions. You will work with a tight-knit and interdisciplinary team and have the opportunity to work with a variety of technologies as well as functional areas within the company. Important note: Even if you are missing one or more of the “priority skills,“ please still apply. Our first priority is to identify talented, motivated, and diverse individuals that will continue to grow and learn.
-
-**Responsibilities**
-
-* Design, deploy and monitor infrastructure in public clouds (AWS, Azure, GCP, DigitalOcean)
-* Propose, develop, and support automated solutions for container testing, deployment, orchestration, and computation
-* Interact with our high-performance workflow team to design, develop, and support hybrid physics-based and machine-learning frameworks
-
-**Priority Skills / Requirements**
-
-* BS (or equivalent or higher) in Computer Science, Physical Sciences, Engineering, or related
-* Strong problem-solving, collaboration, communication skills
-* Experience with one or more major cloud providers (AWS, Azure, GCP)
-* Experience with containerization and orchestration software (Kubernetes, etc.)
-* Experience with CI / CD pipelines, and familiarity with at least one CI platform
-* Experience with one or more cloud-based batch systems (SQS, GCP/Azure/AWS Batch)
-
-**Bonus / Preferred Skills**
-
-* Experience with Git, and strong Python programming skills
-* Experience with Conda package manager and distributed workflow tools (Dask, Airflow, Prefect)
-* Experience with Jupyter/Jupyter Hub, Helm, SQL databases, Redis, or other Pub/Sub tools
-* Ability to work in Pasadena, CA (remote work is possible)
-
-To apply, submit a Cover Letter and Resume to Nicholas Miller at `<nick@entos.info>`.
+We might sometimes advertise for additional job opportunities in the associated research groups. For a more extensive list of academic and industry job postings in computational chemistry, please visit [Alchemistry.org](http://www.alchemistry.org/wiki/Job_postings), [jobrXiv](https://jobrxiv.org/) or [CCL.net](http://ccl.net/chemistry/announcements/jobs/index.shtml). 


### PR DESCRIPTION
- Expanded the job description for QM role
- Removed ads for the Chodera lab positions and Entos
- Added a pointer to Alchemistry.org, CCL.net and jobrXiv for additional job opportunities in comp chem