### PR TITLE
Moving Chaya to Alumni section

### DIFF
--- a/data/members/Chaya_Stern.yaml
+++ b/data/members/Chaya_Stern.yaml
@@ -1,5 +1,5 @@
 name: Chaya Stern
-role: Researcher
+role: alum
 lab: Chodera lab
 title: Tri-Institutional Program in Chemical Biology Graduate Student
 institution: Sloan Kettering Institute


### PR DESCRIPTION
Moving Chaya Stern from "Researchers" to "Alumni" category on the Members page. 