### PR TITLE
Replacing OpenFF internal calendar with a public one

### DIFF
--- a/content/community/events/event-calendar/_index.md
+++ b/content/community/events/event-calendar/_index.md
@@ -4,9 +4,9 @@ title: Event calendar
 weight: 3
 ---
 
-### The Open Force Field Initiative organizes regular team meetings, webinars and workshops, both in person and virtual. Check our calendar for the upcoming events and see more information below about past and future events.
+### The Open Force Field Initiative organizes regular team meetings, webinars and workshops, both in person and virtual. Check our calendar for the upcoming public events and see more information below about past and future events.
 {{< br >}}
-{{< calendar "https://calendar.google.com/calendar/embed?src=openforcefield.org_acehqcu5o51ti8j0vpum493g90%40group.calendar.google.com&ctz=Pacific%2FAuckland" >}}
+{{< calendar "https://calendar.google.com/calendar/embed?src=c_4v40e10csf3j35bi2eq3h79mfg%40group.calendar.google.com&ctz=Pacific%2FAuckland" >}}
 
 **Public address:**
-[Google Calendar Open Force Field](https://calendar.google.com/calendar/embed?src=openforcefield.org_acehqcu5o51ti8j0vpum493g90%40group.calendar.google.com&ctz=Pacific%2FAuckland)
+[Google Calendar Open Force Field](https://calendar.google.com/calendar/embed?src=c_4v40e10csf3j35bi2eq3h79mfg%40group.calendar.google.com&ctz=Pacific%2FAuckland)


### PR DESCRIPTION
I made a public event calendar to be shared on the website (called Open Force Field Event Calendar), where all OpenFF public facing events will be noted. This new public calendar will replace the link to our internal calendar (called Open Force Field), which contains information about all internal meetings. 

