### PR TITLE
Adding EOI form to the Careers page

### DIFF
--- a/content/about/careers/openff/_index.md
+++ b/content/about/careers/openff/_index.md
@@ -3,4 +3,10 @@ title: OpenFF positions
 weight: 1
 ---
 
-Please see the available positions listed below. For more information, please reach out to `info@openforcefield.org`.
+Please see the available positions listed below and apply using the appropriate form provided with each job description. For any additional information, contact `info@openforcefield.org`.
+
+#### Expression of interest
+
+If you are interested in working with the OpenFF Initiative, but there is no job opening that matches your skills at the moment, please fill out the form linked below to express your interest in the future positions. All applications sent here will be reviewed on a monthly basis. If you are applying for an advertised position, please use the appropriate form linked in the job description ad. If your experience and skills will match any future openings, we'll reach out to you to arrange next steps. Contact `info@openforcefield.org` if you have any questions.
+
+Express your interest using this [**APPLICATION FORM**](https://forms.gle/6QwHnUM4x9hUcxALA).

--- a/content/about/careers/openff/pd-biopolymer-2020.md
+++ b/content/about/careers/openff/pd-biopolymer-2020.md
@@ -5,7 +5,7 @@ title: "Postdoctoral position: Biopolymer force fields"
 
 The [Open Force Field Consortium](https://openforcefield.org/about/organization/#open-force-field-consortium) is seeking a postdoctoral fellow to work on the development of biopolymer (protein and potentially nucleic acid) force fields and supporting infrastructure for biopolymer parameterization and benchmarking.
 
-Please fill out this [**form**](https://forms.gle/hypPwzdYBnTRirG97) if you are interested in this position.
+ If you are interested in this position, please fill out this [**APPLICATION FORM**](https://forms.gle/hypPwzdYBnTRirG97).
 
 #### Position description
 


### PR DESCRIPTION
A permanent EOI form added to the Careers page -- this form will collect applications of people interested in joining the OpenFF Initiative when there are no openings that match their skills and experience (as a continuous search support). 