### PR TITLE
Removing a hidden character visible only on mobile Chrome

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ description="Software permissively licensed under the MIT License and developed 
 [[sections]]
 image = "images/icons/open-science.svg"
 title = "Open science"
-description="Scientific reports as blog posts, webinars  and preprints"
+description="Scientific reports as blog posts, webinars and preprints"
 
 [[sections]]
 image = "images/icons/open-data.svg"


### PR DESCRIPTION
A weird character was displayed on the mobile version of Chrome browser, checking if there was a hidden character that caused it.

![image](https://user-images.githubusercontent.com/32760282/94657183-8dc0d980-035d-11eb-9b61-6878682b8166.png)



