### PR TITLE
Add Entos to Careers/External Opportunties

### DIFF
--- a/content/about/careers/external/_index.md
+++ b/content/about/careers/external/_index.md
@@ -4,3 +4,7 @@ weight: 2
 ---
 We might sometimes advertise for additional job opportunities in the associated research groups. For a more extensive list of academic and industry job postings in computational chemistry, please visit [_Alchemistry.org_](http://www.alchemistry.org/wiki/Job_postings), [_jobrXiv_](https://jobrxiv.org/) or [_CCL.net_](http://ccl.net/chemistry/announcements/jobs/index.shtml).
 {{< br >}}{{< br >}}
+
+#### Entos
+
+[Entos](https://www.entos.ai/) is a startup dedicated to accelerating molecular discovery through physics-based machine learning, based in Los Angeles. They are seeking talented software scientists and engineers to join their team, led by [Daniel Smith](http://linkedin.com/in/daniel-smith-a656416a), our current advisor and [OpenFF alumnus](/about/team/#alumni). For a full list of available positions, please check [here](https://www.linkedin.com/company/entos-inc/jobs/). 


### PR DESCRIPTION
Added links to Entos and their LinkedIn job page on Careers/External Opportunities.

![image](https://user-images.githubusercontent.com/32760282/96326668-f793ef80-108e-11eb-849b-d7b9395e0c71.png)
