### PR TITLE
Replacing J. Hert with X. Lucas as the main Roche rep

### DIFF
--- a/content/about/organization/_index.md
+++ b/content/about/organization/_index.md
@@ -85,10 +85,10 @@ The [Open Force Field Consortium officially launched](/community/news/news/intro
 {{< ul >}}
 - [Cristopher Bayly](https://www.linkedin.com/in/christopher-bayly-b1341021/) (OpenEye)
 - [Thomas Fox](https://www.linkedin.com/in/thomas-fox-11b44b54/) (Boehringer-Ingelheim)
-- [Jérôme Hert](https://www.linkedin.com/in/jeromehert/) (Roche)
 - [Xinjun Hou](https://www.linkedin.com/in/xjhou) (Pfizer)
 - [Daniel Kuhn](https://www.linkedin.com/in/daniel-kuhn-23207a5/) (Merck KGaA), Chair
 - [Sirish Kaushik Lakkaraju](https://www.linkedin.com/in/sirish-kaushik-lakkaraju-8906657/) (Bristol-Myers Squibb)
+- [Xavier Lucas](https://www.linkedin.com/in/xlucas/) (Roche)
 - [Mark Mackey](https://www.linkedin.com/in/mark-mackey-6b4b8a23/) (Cresset)
 - [Katharina Meier](https://www.linkedin.com/in/katharina-meier-24744887/) (Bayer)
 - [Arjun Narayanan](https://www.linkedin.com/in/arjun-narayanan-0ba28a54/) (Vertex), Secretary
@@ -108,12 +108,12 @@ The [Open Force Field Consortium officially launched](/community/news/news/intro
 - [Boehringer-Ingelheim](https://www.boehringer-ingelheim.com/)
 - [Bristol-Myers Squibb](https://www.bms.com/)
 - [Cresset](https://www.cresset-group.com/)
+- [F. Hoffman-La Roche AG](https://www.roche.com/)
 - [GlaxoSmithKline](https://www.gsk.com/en-gb/)
 - [Janssen](https://www.janssen.com/)
 - [Merck KGaA](https://www.merckgroup.com/en)
 - [OpenEye](https://www.eyesopen.com/)
 - [Pfizer](https://www.pfizer.com/)
-- [F. Hoffman-La Roche AG](https://www.roche.com/)
 - [Vertex Pharmaceuticals](https://www.vrtx.com/)
 {{< /ul >}}
 {{< br >}}


### PR DESCRIPTION
Jerome Hert requested to be replaced by Xavier Lucas as the main Roche representative on the OpenFF Advisory Board. Updating the website to reflect this change.