### PR TITLE
Add button linking to toolkit installation instructions

### DIFF
--- a/content/software/_index.md
+++ b/content/software/_index.md
@@ -44,7 +44,8 @@ The toolkit currently covers two main areas we have committed to stably maintain
 Lead Developer: Jeffrey Wagner
 
 {{<button href="https://github.com/openforcefield/openforcefield" text="GitHub" >}}
-{{<button href="https://open-forcefield-toolkit.readthedocs.io/en/0.6.0/" text="Documentation" >}}
+{{<button href="https://open-forcefield-toolkit.readthedocs.io/" text="Documentation" >}}
+{{<button href="https://open-forcefield-toolkit.readthedocs.io/en/latest/installation.html" text="Installation" >}}
 {{< br >}}{{< br >}}
 ## OpenFF Evaluator
 


### PR DESCRIPTION

Fixes #332 

I managed to build this locally and it looks fine and points to the right link.

If this is a useful change, it should be straightforward enough to copy+paste the one-liner to add buttons for other packages.