### PR TITLE
Fix the link to OpenFF Toolkit documentation

### DIFF
--- a/content/software/_index.md
+++ b/content/software/_index.md
@@ -51,7 +51,7 @@ The toolkit currently covers two main areas we have committed to stably maintain
 Lead Developer: Jeffrey Wagner
 
 {{<button href="https://github.com/openforcefield/openforcefield" text="GitHub" >}}
-{{<button href="https://open-forcefield-toolkit.readthedocs.io/" text="Documentation" >}}
+{{<button href="https://open-forcefield-toolkit.readthedocs.io/en/latest/" text="Documentation" >}}
 {{<button href="https://open-forcefield-toolkit.readthedocs.io/en/latest/installation.html" text="Installation" >}}
 {{< br >}}{{< br >}}
 ## OpenFF Evaluator


### PR DESCRIPTION
Fix the link to OpenFF Toolkit documentation to point to the `latest` instead of 0.1.0 