### PR TITLE
add link to openff discourse forum

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -156,7 +156,7 @@ enableEmoji = true
 
       [[menu.main]]
         name = "Forum"
-        url = "/community/forum/"
+        url = "https://discourse.openforcefield.org/"
         parent = "community"
         identifier = "forum"
         weight = 5


### PR DESCRIPTION
Redirecting to [OpenFF Discourse forum](https://discourse.openforcefield.org/) from the website. 