### PR TITLE
Change Lily and Simon's roles

### DIFF
--- a/data/members/Lily_Wang.yaml
+++ b/data/members/Lily_Wang.yaml
@@ -1,13 +1,13 @@
 name: Lily Wang
-role: Researcher
-filter-role: Scientific Staff
-lab: Mobley lab
-title: Fulbright Fellow, Australian National University and University of California, Irvine
-institution: Australian National University / University of California, Irvine
+role: Science Lead
+filter-role: Management, Scientific Staff
+lab:
+title:
+institution:
 img: lily-wang.jpg
-description: _Polymer force fields_
+description: _OpenFF software development and architecture, parameterization of force fields_
 twitter: lilyminium
 github: lilyminium
 linkedin: lilyminium
-webpage: https://minium.com.au/
+webpage:
 ORCID: 0000-0002-6095-6704

--- a/data/members/Simon_Boothroyd.yaml
+++ b/data/members/Simon_Boothroyd.yaml
@@ -1,6 +1,6 @@
 name: Simon Boothroyd
 role: Science Lead
-filter-role: Management, Scientific Staff
+filter-role: Alumni
 lab:
 title: 
 institution:


### PR DESCRIPTION
I changed my role to science lead and Simon's status to alumni. Render of my section is below -- Simon's has not changed but has moved to the alumni tab:
<img width="533" alt="Screen Shot 2022-06-02 at 7 45 11 am" src="https://user-images.githubusercontent.com/31115101/171507643-c656ce13-e627-402e-9fb5-4d989129d4cb.png">
 (highlighting mine, as part of ctrl+f)
