### PR TITLE
Add Science  and Force Fields subdirectories in footer

### DIFF
--- a/content/footer/index.md
+++ b/content/footer/index.md
@@ -33,8 +33,20 @@
   title = "Science"
   url = "/science"
   [[column2]]
+    title = "Research"
+    url = "/science/research"
+    parent = "science"
+  [[column2]]
     title = "Publications"
     url = "/science/publications"
+    parent = "science"
+  [[column2]]
+    title = "Collaborative projects"
+    url = "/science/collaborative-projects/"
+    parent = "science"
+  [[column2]]
+    title = "How to Cite"
+    url = "/science//how-to-cite/"
     parent = "science"
 
 [[column2]]
@@ -45,9 +57,17 @@
   title = "Data"
   url = "/data"
 
-[[column2]]
+[[column3]]
   title = "Force Fields"
-  url = "/forcefields"
+  url = "/force-fields"
+  [[column3]]
+    title = "Force Fields"
+    url = "/force-fields/force-fields"
+    parent = "force-fields"
+  [[column3]]
+    title = "Versioning"
+    url = "/force-fields/versioning"
+    parent = "force-fields"
 
 [[column3]]
   title = "Community"

--- a/content/footer/index.md
+++ b/content/footer/index.md
@@ -49,11 +49,11 @@
     url = "/science//how-to-cite/"
     parent = "science"
 
-[[column2]]
+[[column3]]
   title = "Software"
   url = "/software"
 
-[[column2]]
+[[column3]]
   title = "Data"
   url = "/data"
 
@@ -69,26 +69,26 @@
     url = "/force-fields/versioning"
     parent = "force-fields"
 
-[[column3]]
+[[column4]]
   title = "Community"
   url = "/community"
-  [[column3]]
+  [[column4]]
     title = "News"
     url = "/community/news"
     parent = "news"
-  [[column3]]
+  [[column4]]
     title = "Events"
     url = "/community/events"
     parent = "news"
-  [[column3]]
+  [[column4]]
     title = "Collaborate"
     url = "/community/collaborate"
     parent = "news"  
-  [[column3]]
+  [[column4]]
     title = "FAQ"
     url = "/community/faq"
     parent = "news"  
-  [[column3]]
+  [[column4]]
     title = "Forum"
     url = "/community/forum"
     parent = "news"

--- a/themes/openff/assets/sass/footer.scss
+++ b/themes/openff/assets/sass/footer.scss
@@ -23,7 +23,7 @@ footer {
   > div {
     display: inline-block;
     vertical-align: top;
-    width: 19%;
+    width: 15%;
     + div {
       padding-left: 3*$padding;
     }
@@ -35,6 +35,7 @@ footer {
     &.footer-right {
       white-space: nowrap;
       font-weight: bold;
+      width: fit-content;
       @media (max-width: $breakpoint-phone) {
         padding-top: 1rem;
       }

--- a/themes/openff/layouts/partials/footer.html
+++ b/themes/openff/layouts/partials/footer.html
@@ -36,6 +36,15 @@
 			{{ end }}
 		{{ end }}
 	</div>
+	<div class="footer-column4">
+		{{ range $footer.Params.column4 }}
+			{{ if .url }}
+				<a href="{{ .url }}" class="{{ if .parent }}footer-has-child{{ end }}">{{ .title }}</a>
+			{{ else }}
+				<div>{{ .title }}</div>
+			{{ end }}
+		{{ end }}
+	</div>
 	<div class="footer-right">
 		{{ range $footer.Params.right }}
 			{{ if .icon }}


### PR DESCRIPTION
Current footer:

![image](https://user-images.githubusercontent.com/59344/176197261-aa7c42a2-08ea-4511-88c0-7ee72813e2c0.png)

However, if you currently click on the `Force Fields` link in the footer, you will be redirected to https://openforcefield.org/forcefields which gives a 404 error.

This pull request rearranges the footer to look like this:

![image](https://user-images.githubusercontent.com/59344/176197640-399f46e9-15e3-41b6-ac0a-468b4958f961.png)

It adds the missing subdirectories `Research`, `Collaborative projects` and `How to cite` under `Science` and the `Force Fields`and `Versioning` subdirectories under `Force Fields`.

Note that `FAQ` now is partially hidden and `Forum` is no longer visible. This can probably be resolved by increasing the height of the footer but I couldn't figure out how to do that.