### PR TITLE
Add link to software documentation to index

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -22,4 +22,5 @@ description="Curated quantum chemical and experimental datasets used to paramete
 +++
 {{< button href="/community/news/general" text="News" >}}
 {{< button href="https://github.com/openforcefield/openforcefield/tree/master/examples#examples-using-smirnoff-with-the-toolkit" text="Tutorials" >}}
+{{< button href="https://docs.openforcefield.org/" text="Documentation" >}}
 {{< button href="/about/roadmap/" text="Roadmap" >}}


### PR DESCRIPTION
Adds a link to our [documentation landing page](https://docs.openforcefield.org) to the site's index page.