### PR TITLE
Update tutorials link to use new examples page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -21,6 +21,6 @@ description="Curated quantum chemical and experimental datasets used to paramete
 
 +++
 {{< button href="/community/news/general" text="News" >}}
-{{< button href="https://github.com/openforcefield/openforcefield/tree/master/examples#examples-using-smirnoff-with-the-toolkit" text="Tutorials" >}}
+{{< button href="https://docs.openforcefield.org/examples" text="Tutorials" >}}
 {{< button href="https://docs.openforcefield.org/" text="Documentation" >}}
 {{< button href="/about/roadmap/" text="Roadmap" >}}


### PR DESCRIPTION
The new [examples page](https://docs.openforcefield.org/examples) is live! This updates the link on the openforcefield.org home page to point to it instead of the Toolkit's examples folder on GitHub. The new page includes examples from other projects, convenient download and Colab links, and a more polished presentation.