### PR TITLE
Update the How To Join page

### DIFF
--- a/content/how-to-join/_index.md
+++ b/content/how-to-join/_index.md
@@ -4,7 +4,7 @@ title: Join us!
 ---
 
 ##### If you and the company you represent are interested in joining Open Force Field as industrial partners, there are a couple of different options for how to proceed:
-1. You can download this [slide deck](https://zenodo.org/record/6774452/files/2022%20Annual%20Keynote%20-%20Public%20Copy.pdf?download=1) to get an idea of what we have already done and what we can still do, and watch our [latest virtual workshop](https://youtu.be/YA3PpeFFcqk) in which we talk about both the science and the technology we are developing.
+1. You can watch the [keynote address from our latest annual meeting](https://youtu.be/RzqqNytqbeY) and download the [slide deck](https://zenodo.org/record/8044738/files/2023%20OpenFF%20Keynote.pdf?download=1) to get an idea of what we have already done and what we can still do, and watch our [latest virtual workshop](https://www.youtube.com/watch?v=ojlxHiJ3M-4) in which we talk about both the science and the technology we are developing.
 2. You can email us at <a href="mailto:info@openforcefield.org">info@openforcefield.org</a> to schedule a short virtual meeting in which we will introduce the big picture of the Open Force Field Initiative. At this meeting we can go through the different membership levels and additional ways to contribute.
 3. Our team can make a formal presentation about the Open Force Field Initiative to you or your team. In this presentation we can go through the current status of projects and our plans in detail. Just email us at <a href="mailto:info@openforcefield.org">info@openforcefield.org</a>.
 
@@ -14,5 +14,5 @@ If you would like to spread the word about the Open Force Field Initiative, plea
 
 * [Single-slide overview of what we do](https://docs.google.com/presentation/d/1Sl_XWkIrDsFl6RbEh7UDAyuEFyepqXct3JsCZ2n2ObE/edit?usp=sharing)
 
-* [Brief slide deck on the project](https://zenodo.org/record/7430414#.Y5e3sy8w3VN)
+* [Brief slide deck on the project](https://doi.org/10.5281/zenodo.8144799)
 


### PR DESCRIPTION
Refreshed the links on the how to join page to include presentations from OMSF symposium in May 2023 and an updated general pitch deck.