### PR TITLE
2024 mini workshops blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See more detailed instructions for creating or updating content below.
 
 ## Preview the website locally
 
-0. [Download and install Hugo](https://gohugo.io/getting-started/installing/). Note that the website will finally be built with Hugo v0.108.0.
+0. [Download and install Hugo](https://gohugo.io/getting-started/installing/). Note that the published version of the website will be built with Hugo v0.108.0 (this isn't the latest version).
 1. In the top-level directory, run `hugo server -D`
 2. Copy the Web address from this line (in this example, it is `localhost:1313`):
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See more detailed instructions for creating or updating content below.
 
 ## Preview the website locally
 
-0. [Download and install Hugo](https://gohugo.io/getting-started/installing/).
+0. [Download and install Hugo](https://gohugo.io/getting-started/installing/). Note that the website will finally be built with Hugo v0.108.0.
 1. In the top-level directory, run `hugo server -D`
 2. Copy the Web address from this line (in this example, it is `localhost:1313`):
 ```
@@ -24,6 +24,13 @@ Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
 ```
 3. Paste the Web address into your browser
 
+If you have NPM installed, the appropriate version of Hugo can be installed and executed in one command, without interfering with any existing installations:
+
+```shell
+npx hugo-bin@0.108.0 server -D
+```
+
+Then open the provided link as above.
 
 ## Creating and updating content
 

--- a/content/community/news/general/2024_mini_workshops.md
+++ b/content/community/news/general/2024_mini_workshops.md
@@ -1,0 +1,46 @@
+---
+date: "2024-07-19T00:00:00+00:00"
+title: "2024 Online OpenFF Mini-Workshops"
+tags: ["news","general","newsletter","Open Force Field Initiative"]
+categories: ["news"]
+draft: false
+description: "The 2024 mini workshops are now available on YouTube and as Jupyter notebooks!"
+weight: 10
+author: "Josh Mitchell"
+thumb: "openff-rocket.png"
+---
+
+OpenFF ran a series of online workshops in February--April this year. Since then, we have updated materials to take account of issues encountered during the workshops and uploaded re-recordings of all three sessions to YouTube. If you're interested in understanding the SMIRNOFF force field format, open source protein preparation workflows, or learning about some fun new features and capabilities of the OpenFF ecosystem, take a look!
+
+If you'd like to follow along, each Jupyter notebook worked through in these workshops are available on Google Colab without installing anything on your computer, but we recommend downloading the zipped materials files and installing the software with the included Conda environment to run the workshop locally.
+
+## SMIRNOFF Force Fields and You
+
+
+SMIRNOFF is an open format for specifying molecular mechanics force fields directly for the chemistry of a target molecule, rather than indirectly through abstractions like atom types. Unlike other force field formats, SMIRNOFF describes not only the parameters of the force field, but also the chemistries to which those parameters should be applied.
+
+This workshop introduces the SMIRNOFF format to familiar MD practitioners and describes how a system can be parametrized from a SMIRNOFF force field for a number of different MD engines. We hope to get both users and developers of molecular mechanics force fields excited about this game changing format.
+
+{{< youtube qpmxqjKHlzY >}}
+
+Materials: https://docs.openforcefield.org/workshops/2024/smirnoff.html#workshop-materials
+
+## Protein Preparation in Jupyter
+
+Today, Jupyter notebooks are everything you need to prepare a molecular dynamics simulation. Not only do they provide a unified interface to all the tools needed to prepare and visualize a simulation, they also provide an easy way to record, repeat, and even publish your workflow, including any alterations needed for a particularly stubborn system.
+
+This workshop covers the preparation of a protein system from a structure downloaded from the PDB, entirely in the Jupyter notebook, complete with 3D visualizations at every step of the way. We hope to make it accessible even to new MD practitioners, assuming they have some familiarity with Python.
+
+{{< youtube pwfKE6wPaMg >}}
+
+Materials: https://docs.openforcefield.org/workshops/2024/protein_prep.html#workshop-materials
+
+## Things to Make and Do with OpenFF Tools
+
+Today, Jupyter notebooks are everything you need to prepare a molecular dynamics simulation. Not only do they provide a unified interface to all the tools needed to prepare and visualize a simulation, they also provide an easy way to record, repeat, and even publish your workflow, including any alterations needed for a particularly stubborn system.
+
+This workshop covers the preparation of a protein system from a structure downloaded from the PDB, entirely in the Jupyter notebook, complete with 3D visualizations at every step of the way. We hope to make it accessible even to new MD practitioners, assuming they have some familiarity with Python.
+
+{{< youtube qs2cVX2rpD4 >}}
+
+Materials: https://docs.openforcefield.org/workshops/2024/vignettes.html#workshop-materials

--- a/themes/openff/layouts/shortcodes/youtube.html
+++ b/themes/openff/layouts/shortcodes/youtube.html
@@ -1,1 +1,0 @@
-<iframe width="560" height="315" src="{{.Get 0}}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>


### PR DESCRIPTION
This adds a blog post linking to the long-awaited 2024 mini workshops. It also fixes the YouTube shortcode to make it easy to embed YouTube videos in posts and adds a note to the README describing how to run the appropriate version of Hugo with NPX, as modern versions of Hugo have broken the site. 