### PR TITLE
Try manually bumping `actions/upload-pages-artifact` to v3

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "https://openforcefield.org/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         if: github.ref == 'refs/heads/v2'
         with:
           path: ./public


### PR DESCRIPTION
#503 is failing because of 
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

which probably called by a seperate action (`actions/upload-pages-artifact`) ... which is tagged to v1 when there's a v3 out