### PR TITLE
Allow reverse ordering by weight

### DIFF
--- a/content/community/events/1st-Open-Force-Field-Workshop/index.md
+++ b/content/community/events/1st-Open-Force-Field-Workshop/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 99
+date: "2019-01-07"
 title: 1st Open Force Field Workshop
 description: The First Open Force Field Workshop was held in La Jolla, CA on January 7-8, 2019. The meeting was open to Consortium members and collaborators, and parts of the meeting were recorded for posting online. Watch the videos from this workshop on YouTube and access presentation slides on Zenodo.
 foldopen: true

--- a/content/community/events/2024-Mini-Workshops/index.md
+++ b/content/community/events/2024-Mini-Workshops/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 10
+date: "2024-02-01"
 title: "2024 Online OpenFF Mini-Workshops"
 description: "The 2024 mini workshops are now available on YouTube and as Jupyter notebooks!"
 foldopen: true

--- a/content/community/events/2024-OMSF-Symposium/index.md
+++ b/content/community/events/2024-OMSF-Symposium/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 10
+date: "2024-05-16"
 title: 2024 OMSF Symposium
 description: Open Force Field presented at the 2024 Open Molecular Software Foundation Symposium.
 foldopen: true

--- a/content/community/events/2025-OMSF-Symposium/index.md
+++ b/content/community/events/2025-OMSF-Symposium/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 9
+date: "2025-05-09"
 title: 2025 OMSF Symposium
 description: Open Force Field presented at the 2025 Open Molecular Software Foundation Symposium.
 foldopen: true

--- a/content/community/events/2026-OMSF-Symposium/index.md
+++ b/content/community/events/2026-OMSF-Symposium/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 1
+date: "2026-02-07"
 title: 2026 OMSF Symposium
 description: Open Force Field will present at the 2026 Open Molecular Software Foundation Symposium.
 foldopen: true

--- a/content/community/events/2026-Virtual-Workshops/index.md
+++ b/content/community/events/2026-Virtual-Workshops/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 1
+date: "2026-02-01"
 title: 2026 Virtual Workshops
 description: Open Force Field is planning a series of virtual workshops in 2026
 foldopen: true

--- a/content/community/events/2nd-Open-Force-Field-Workshop/index.md
+++ b/content/community/events/2nd-Open-Force-Field-Workshop/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 98
+date: "2019-08-30"
 title: 2nd Open Force Field Workshop
 description: We hosted the Second Open Force Field Workshop  again in La Jolla, CA on August 30-31, 2019. The first two days of the workshop focused on the progress update and future planning of OpenFF efforts in Year 2. The workshop was extended for another day (Sep 1), which was reserved for OpenFF team discussions, but open to interested Industry Partners. The venue was provided by the Skaggs School of Pharmacy and Pharmaceutical Sciences at UCSD campus.
 foldopen: true

--- a/content/community/events/3rd-Open-Force-Field-Workshop/index.md
+++ b/content/community/events/3rd-Open-Force-Field-Workshop/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 97
+date: "2020-05-04"
 title: 3rd Open Force Field Workshop
 description: The Third Open Force Field Workshop was initially as an in-person gathering in Boston on May 4-5, 2020, but this meeting was cancelled due to the Covid-19 outbreak. This in-person meeting was replaced by a virtual meeting on the same dates. We decided to slightly experiment with the workshop format by making most of the content available before the meeting for asynchronous consumption.
 foldopen: true

--- a/content/community/events/4th-Open-Force-Field-Workshop/index.md
+++ b/content/community/events/4th-Open-Force-Field-Workshop/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 96
+date: "2021-06-01"
 title: 4th Open Force Field Workshop
 description: The 4th Open Force Field Workshop was held as a series of online presentations over several months in 2021.
 foldopen: true

--- a/content/community/events/5th-Open-Force-Field-Workshop/index.md
+++ b/content/community/events/5th-Open-Force-Field-Workshop/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 95
+date: "2022-06-01"
 title: 5th Open Force Field Workshop
 description: The 5th Open Force Field Workshop was held as a series of online presentations over several months in 2022.
 foldopen: true

--- a/content/community/events/6th-Open-Force-Field-Workshop/index.md
+++ b/content/community/events/6th-Open-Force-Field-Workshop/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 94
+date: "2023-05-14"
 title: 6th Open Force Field Workshop
 description: The 6th Open Force Field Workshop was held as a part of the 2023 Open Molecular Software Foundation Symposium.
 foldopen: true

--- a/content/community/events/_index.md
+++ b/content/community/events/_index.md
@@ -2,6 +2,8 @@
 color: darkblue
 title: Events
 class: 'table-with-time'
+cascade:
+  hidedate: true
 ---
 
 ##### The Open Force Field Initiative organizes regular team meetings, webinars and workshops, both in person and virtual. See more information below about past and future events.

--- a/content/community/events/webinars/index.md
+++ b/content/community/events/webinars/index.md
@@ -1,6 +1,6 @@
 ---
 color: darkblue
-weight: 0
+date: "2019-01-01"
 title: Webinars
 description: OpenFF held a series of webinars in 2019
 foldopen: true

--- a/themes/openff/layouts/_default/list.html
+++ b/themes/openff/layouts/_default/list.html
@@ -8,7 +8,7 @@
 			{{ with .Content }}<div>{{ . }}</div>{{ end }}
 		</div>
 		{{ end }}
-		{{ range .Paginator.Pages.ByWeight }}
+		{{ range .Paginator.Pages.ByDate.Reverse }}
 			<div>
 				{{ if .Params.thumb }}
 				<div class="item-thumb">
@@ -29,16 +29,16 @@
 						{{ else }}
 							<a href="{{ .Permalink }}">{{ .Title }}</a>
 						{{ end }}
-						{{ if or .Date .Params.Author }}
+						{{ if or (and .Date (not .Params.hidedate)) .Params.Author }}
 							<h6>
 						{{ end }}
-						{{ if .Date }}
+						{{ if and .Date (not .Params.hidedate) }}
 							Posted on {{ .Date.Format "2 Jan 2006" }}
 						{{ end }}
 						{{ if .Params.Author }}
 							by {{ .Params.Author }}
 						{{ end }}
-						{{ if or .Date .Params.Author }}
+						{{ if or (and .Date (not .Params.hidedate)) .Params.Author }}
 							</h6>
 						{{ end }}
 					</h2>


### PR DESCRIPTION
I noticed the issue with ordering by weights. I had Claude take a crack at it, and if instead of weights there are dates then the layout.html can be set to sort by reverse date. All other pages have equal weights so this list feature wasn't used and turning it to "reverse" won't affect them.

You shouldn't notice any difference with the website using this PR. 

Notice that the dates on the 2026 posts are for the past. Apparently we can add dates in the future and the associated page won't render/appear until that date. You prob knew that but I thought it was cool.