### PR TITLE
remove dead link to OMSF blog

### DIFF
--- a/content/community/news/science-updates/_index.md
+++ b/content/community/news/science-updates/_index.md
@@ -9,6 +9,4 @@ Regular updates from our Infrastructure and Science teams are posted to the [Ope
 
 ___
 
-Other new science updates are now being shared on the [OMSF blog](https://blog.omsf.io/tag/open-force-field/). 
-
 Older science update posts are available below.


### PR DESCRIPTION
There are still OpenFF posts mixed into the new OMSF substack, but there's not tagging system to send people to directly to them so I've decided not to link there from this page.