### PR TITLE
Sort projects by pipeline stage

### DIFF
--- a/content/about/roadmap/css/project.css
+++ b/content/about/roadmap/css/project.css
@@ -57,21 +57,34 @@ article:has(#project-hero) > h1 { display: none; }
   position: relative;
 }
 
-/* connector line between stages */
+/* Connector line between stages. Each stage colours the near half of its
+   adjacent segments (::after = half toward the next stage, ::before = half
+   toward the previous one), so two active stages meet at the midpoint to form a
+   continuous bar, while a skipped stage leaves a centred gap. */
 .pipeline-stage:not(:last-child)::after {
   content: "";
   position: absolute;
   top: 18px;
-  right: -1px;
-  width: calc(100% - 36px);
   left: calc(50% + 16px);
+  right: 0;
   height: 2px;
   background: var(--color-border);
   z-index: 0;
 }
 
-.pipeline-stage.active:not(:last-child)::after,
-.pipeline-stage + .pipeline-stage.active::before {
+.pipeline-stage:not(:first-child)::before {
+  content: "";
+  position: absolute;
+  top: 18px;
+  left: 0;
+  right: calc(50% + 16px);
+  height: 2px;
+  background: var(--color-border);
+  z-index: 0;
+}
+
+.pipeline-stage.active::before,
+.pipeline-stage.active::after {
   background: var(--color-accent);
 }
 

--- a/content/about/roadmap/css/project.css
+++ b/content/about/roadmap/css/project.css
@@ -41,10 +41,16 @@ article:has(#project-hero) > h1 { display: none; }
 }
 
 .pipeline-stepper {
+  /* geometry shared by the dots and their connector lines */
+  --stage-dot-size: 36px;
+  --stage-line-thickness: 2px;
   display: flex;
   align-items: stretch;
   gap: 0;
   overflow-x: auto;
+  /* overflow-x:auto forces overflow-y to clip rather than stay visible, so pad
+     the top to keep the active dot's box-shadow ring from being cut off */
+  padding-top: 0.5rem;
   padding-bottom: 0.25rem;
 }
 
@@ -64,10 +70,12 @@ article:has(#project-hero) > h1 { display: none; }
 .pipeline-stage:not(:last-child)::after {
   content: "";
   position: absolute;
-  top: 18px;
-  left: calc(50% + 16px);
+  /* centre the line on the dot: radius minus half the line's thickness */
+  top: calc(var(--stage-dot-size) / 2 - var(--stage-line-thickness) / 2);
+  /* start just inside the dot's right edge (radius, less a 2px overlap) */
+  left: calc(50% + var(--stage-dot-size) / 2 - 2px);
   right: 0;
-  height: 2px;
+  height: var(--stage-line-thickness);
   background: var(--color-border);
   z-index: 0;
 }
@@ -75,10 +83,10 @@ article:has(#project-hero) > h1 { display: none; }
 .pipeline-stage:not(:first-child)::before {
   content: "";
   position: absolute;
-  top: 18px;
+  top: calc(var(--stage-dot-size) / 2 - var(--stage-line-thickness) / 2);
   left: 0;
-  right: calc(50% + 16px);
-  height: 2px;
+  right: calc(50% + var(--stage-dot-size) / 2 - 2px);
+  height: var(--stage-line-thickness);
   background: var(--color-border);
   z-index: 0;
 }
@@ -89,8 +97,8 @@ article:has(#project-hero) > h1 { display: none; }
 }
 
 .stage-dot-wrap {
-  width: 36px;
-  height: 36px;
+  width: var(--stage-dot-size);
+  height: var(--stage-dot-size);
   border-radius: 50%;
   display: flex;
   align-items: center;

--- a/data/roadmap/stages.yaml
+++ b/data/roadmap/stages.yaml
@@ -1,6 +1,23 @@
-infra_updates: "Upfront Infrastructure"
-data_generation: "Data Generation"
-fitting: "Fitting"
-benchmarking: "Benchmarking"
-release: "Release"
-community_maintenance: "Community & Maintenance"
+# Pipeline stages in canonical order. The list order defines how projects are
+# sorted on the roadmap (by their earliest stage); `key` is the front-matter
+# value, `label` the display name, `icon` the inline SVG shown in the pipeline
+# stepper. This must stay an ordered sequence — a map would NOT preserve order,
+# since Hugo iterates data maps by sorted key.
+- key: infra_updates
+  label: "Upfront Infrastructure"
+  icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>'
+- key: data_generation
+  label: "Data Generation"
+  icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>'
+- key: fitting
+  label: "Fitting"
+  icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>'
+- key: benchmarking
+  label: "Benchmarking"
+  icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>'
+- key: release
+  label: "Release"
+  icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="16 12 12 8 8 12"/><line x1="12" y1="16" x2="12" y2="8"/></svg>'
+- key: community_maintenance
+  label: "Community & Maintenance"
+  icon: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>'

--- a/layouts/_default/roadmap-project.html
+++ b/layouts/_default/roadmap-project.html
@@ -12,8 +12,9 @@
 {{/* metrics/go_no_go are commonly not filled in yet for early-stage proposals;
      the template below renders a "not defined yet" placeholder for either,
      so these are not build-breaking like the structural fields above. */}}
+{{ $validStages := apply .Site.Data.roadmap.stages "index" "." "key" }}
 {{ range .Params.stages }}
-  {{ if not (isset $.Site.Data.roadmap.stages .) }}
+  {{ if not (in $validStages .) }}
     {{ errorf "%s: unknown stage %q" $.File.Path . }}
   {{ end }}
 {{ end }}
@@ -59,20 +60,12 @@
         <h2>Pipeline Stages</h2>
       </div>
       {{ $activeStages := .Params.stages }}
-      {{ $stageIcons := slice
-        (dict "key" "infra_updates" "icon" `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>`)
-        (dict "key" "data_generation" "icon" `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>`)
-        (dict "key" "fitting" "icon" `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>`)
-        (dict "key" "benchmarking" "icon" `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>`)
-        (dict "key" "release" "icon" `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="16 12 12 8 8 12"/><line x1="12" y1="16" x2="12" y2="8"/></svg>`)
-        (dict "key" "community_maintenance" "icon" `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`)
-      }}
       <div class="pipeline-stepper">
-        {{ range $stageIcons }}
+        {{ range .Site.Data.roadmap.stages }}
           {{ $active := in $activeStages .key }}
           <div class="pipeline-stage {{ if $active }}active{{ else }}inactive{{ end }}">
             <div class="stage-dot-wrap">{{ .icon | safeHTML }}</div>
-            <span class="stage-label">{{ index $.Site.Data.roadmap.stages .key }}</span>
+            <span class="stage-label">{{ .label }}</span>
           </div>
         {{ end }}
       </div>
@@ -209,7 +202,7 @@
     </section>
 
     <!-- Prev/Next navigation -->
-    {{ $ordered := sort $projectsSection.Pages "File.ContentBaseName" }}
+    {{ $ordered := partial "roadmap-sort-projects.html" $projectsSection.Pages }}
     {{ $idx := 0 }}
     {{ range $i, $p := $ordered }}
       {{ if eq $p.RelPermalink $.RelPermalink }}{{ $idx = $i }}{{ end }}

--- a/layouts/partials/roadmap-sort-projects.html
+++ b/layouts/partials/roadmap-sort-projects.html
@@ -1,0 +1,29 @@
+{{/* Returns a project Page collection sorted for display: recommended projects
+     first, then alternatives; within each group by earliest stage, then latest
+     stage, then title. Projects with no known stage sort last within their group.
+     Expects: a project Page collection. Returns: a sorted slice of Pages. */}}
+{{ $stages := site.Data.roadmap.stages }}
+{{ $ranked := slice }}
+{{ range . }}
+  {{ $page := . }}
+  {{/* first/last = indices of the earliest and latest stages this project spans.
+       Sorting by first then last puts short, early projects ahead of longer
+       ones that start at the same stage. Projects with no stage sort last. */}}
+  {{ $first := len $stages }}
+  {{ $last := 0 }}
+  {{ range $i, $s := $stages }}
+    {{ if in $page.Params.stages $s.key }}
+      {{ if lt $i $first }}{{ $first = $i }}{{ end }}
+      {{ if gt $i $last }}{{ $last = $i }}{{ end }}
+    {{ end }}
+  {{ end }}
+  {{/* recommended projects sort first; zero-pad so a lexical sort is numeric:
+       recommended, then earliest stage, then latest stage, then title */}}
+  {{ $recRank := cond $page.Params.recommended "0" "1" }}
+  {{ $ranked = $ranked | append (dict "page" $page "key" (printf "%s-%03d-%03d-%s" $recRank $first $last $page.Title)) }}
+{{ end }}
+{{ $out := slice }}
+{{ range sort $ranked "key" }}
+  {{ $out = $out | append .page }}
+{{ end }}
+{{ return $out }}

--- a/layouts/shortcodes/roadmap-grid.html
+++ b/layouts/shortcodes/roadmap-grid.html
@@ -1,12 +1,10 @@
-{{/* Renders the "All Projects" card grid: recommended projects first, then alternatives. */}}
+{{/* Renders the "All Projects" card grid. Ordering — recommended first, then by
+     pipeline stage — is handled by the roadmap-sort-projects partial. */}}
 {{ $projSection := .Page.Site.GetPage "/about/roadmap/projects" }}
 {{ $cats := .Page.Site.Data.roadmap.categories }}
 
 <div id="project-grid" style="display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:1rem;">
-  {{ range (where $projSection.Pages "Params.recommended" true) }}
-    {{ partial "roadmap-grid-card" (dict "page" . "cats" $cats) }}
-  {{ end }}
-  {{ range (where $projSection.Pages "Params.recommended" false) }}
+  {{ range (partial "roadmap-sort-projects.html" $projSection.Pages) }}
     {{ partial "roadmap-grid-card" (dict "page" . "cats" $cats) }}
   {{ end }}
 </div>


### PR DESCRIPTION
This PR defines a stable sort that is intuitive to the reader and consistent between the grid and the prev/next buttons on each project page. In particular, it:

1. Reformats `data/roadmap/stages.yaml` so that it defines the order that stages appear in, and that it includes the icons for each stage (rather than them being stored in the project page template)
2. Uses the new single-source-of-truth for all stages information
3. Adds `layouts/partials/roadmap-sort-projects.html` to define a single place where the order of projects is defined, and modifies both the grid and the next/prev project buttons on the project pages to follow this order
4. Uses the new sorting partial to sort first by recommendation, then by earliest pipeline stage, then by latest pipeline stage, then by title.
5. Makes some minor cosmetic changes to how the pipeline is presented on the projects pages for a more thought-out look:

<img width="1038" height="166" alt="image" src="https://github.com/user-attachments/assets/73bc1af2-2d04-4763-bcc8-7bf79659b4e4" />
